### PR TITLE
Implement price query command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,10 +2980,12 @@ version = "0.6.2"
 dependencies = [
  "async-trait",
  "ethers",
+ "iron-abis",
  "iron-types",
  "once_cell",
  "serde",
  "serde_json",
+ "tauri",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
   "crates/sync/alchemy",
   "crates/crypto",
   "crates/broadcast",
-  "crates/exchange-rates",
+  "crates/exchange-rates"
 ]
 default-members = ["bin/iron"]
 

--- a/bin/iron/Cargo.toml
+++ b/bin/iron/Cargo.toml
@@ -22,8 +22,8 @@ iron-types = { workspace = true }
 iron-db = { workspace = true }
 iron-sync = { workspace = true }
 iron-tracing = { workspace = true }
-iron-exchange-rates = { workspace = true }
 iron-broadcast = { workspace = true }
+iron-exchange-rates = { workspace = true }
 tauri = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -54,6 +54,7 @@ impl IronApp {
                 iron_dialogs::commands::dialog_finish,
                 iron_forge::commands::foundry_get_abi,
                 iron_rpc::commands::rpc_send_transaction,
+                iron_exchange_rates::commands::exchange_rates_get_prices,
                 iron_connections::commands::connections_affinity_for,
                 iron_connections::commands::connections_set_affinity,
                 iron_sync::commands::sync_alchemy_is_network_supported

--- a/crates/abis/src/lib.rs
+++ b/crates/abis/src/lib.rs
@@ -30,3 +30,15 @@ abigen!(
     ]"#,
     event_derives(serde::Deserialize)
 );
+
+abigen!(
+    AggregatorV3Interface,
+    r#"[
+        function decimals() external view returns (uint8)
+        function description() external view returns (string memory)
+        function version() external view returns (uint256)
+        function getRoundData(uint80 _roundId) external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+        function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    ]"#,
+    event_derives(serde::Deserialize)
+);

--- a/crates/exchange-rates/Cargo.toml
+++ b/crates/exchange-rates/Cargo.toml
@@ -10,7 +10,9 @@ authors.workspace = true
 
 [dependencies]
 iron-types = { workspace = true }
+iron-abis = { workspace = true }
 
+tauri = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ethers = { workspace = true }

--- a/crates/exchange-rates/res/feeds.json
+++ b/crates/exchange-rates/res/feeds.json
@@ -1,4 +1,23 @@
 {
+  "rpcs": {
+    "1": [
+      "https://rpc.ankr.com/eth",
+      "https://eth.llamarpc.com",
+      "https://rpc.mevblocker.io",
+      "https://rpc.builder0x69.io",
+      "https://ethereum.publicnode.com",
+      "https://1rpc.io/eth",
+      "https://rpc.flashbots.net",
+      "https://eth-rpc.gateway.pokt.network",
+      "https://eth.meowrpc.com"
+    ],
+    "5": [
+      "https://rpc.ankr.com/eth_goerli",
+      "https://endpoints.omniatech.io/v1/eth/goerli/public",
+      "https://eth-goerli.public.blastapi.io",
+      "https://ethereum-goerli.publicnode.com"
+    ]
+  },
   "feeds": {
     "1": {
       "USD": {

--- a/crates/exchange-rates/src/chainlink.rs
+++ b/crates/exchange-rates/src/chainlink.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+use ethers::{
+    providers::{Http, Provider},
+    types::Address,
+};
+use iron_abis::AggregatorV3Interface;
+
+pub async fn get_feed_price<'a>(address: &Address, rpcs: &'a Vec<String>) -> Option<i128> {
+    for rpc in rpcs {
+        if let Ok(provider) = Provider::<Http>::try_from(rpc) {
+            let client = Arc::new(provider);
+            let contract = AggregatorV3Interface::new(*address, client);
+            if let Ok(round_data) = contract.latest_round_data().call().await {
+                let res = round_data.1.as_i128();
+                return Some(res)
+            }
+        }
+    }
+    None
+}

--- a/crates/exchange-rates/src/commands.rs
+++ b/crates/exchange-rates/src/commands.rs
@@ -1,0 +1,7 @@
+use super::Feeds;
+use iron_types::{GlobalState, Json};
+
+#[tauri::command]
+pub async fn exchange_rates_get_prices(params: Json) -> Option<i128> {
+    Feeds::read().await.get_prices(params).await
+}

--- a/crates/exchange-rates/src/feed.rs
+++ b/crates/exchange-rates/src/feed.rs
@@ -1,8 +1,19 @@
 use ethers::types::Address;
 use serde::Deserialize;
 
+use super::chainlink;
+use crate::Feed::Chainlink;
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "provider", rename_all = "camelCase", content = "address")]
 pub enum Feed {
     Chainlink(Address),
+}
+
+impl Feed {
+    pub async fn get_feed_price<'a>(&self, rpcs: &'a Vec<String>) -> Option<i128> {
+        match &self {
+            Chainlink(address) => chainlink::get_feed_price(address, rpcs).await,
+        }
+    }
 }

--- a/crates/exchange-rates/src/init.rs
+++ b/crates/exchange-rates/src/init.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use iron_types::GlobalState;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
+use std::collections::HashMap;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use super::{feed::Feed, Feeds};
+use super::feed::Feed;
+use super::Feeds;
 
 static FEEDS: Lazy<RwLock<Feeds>> = Lazy::new(|| {
     // Embed the JSON file in the binary
@@ -15,11 +15,13 @@ static FEEDS: Lazy<RwLock<Feeds>> = Lazy::new(|| {
     #[derive(Deserialize)]
     struct InputFeeds {
         feeds: HashMap<u64, HashMap<String, HashMap<String, Vec<Feed>>>>,
+        rpcs: HashMap<u64, Vec<String>>,
     }
 
     let res: InputFeeds = serde_json::from_str(feeds_str).unwrap();
     let mut feeds = Feeds {
         feeds: HashMap::new(),
+        rpcs: res.rpcs,
     };
 
     for (k1, v1) in res.feeds {

--- a/crates/exchange-rates/src/lib.rs
+++ b/crates/exchange-rates/src/lib.rs
@@ -1,13 +1,32 @@
+pub mod commands;
+mod chainlink;
 mod feed;
 mod init;
 
-use std::collections::HashMap;
-
 use feed::Feed;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 pub struct Feeds {
     // Tuple structure: (network, currency, token symbol)
     feeds: HashMap<(u64, String, String), Vec<Feed>>,
+    // Map structure: key<network>, value<rpc address list>
+    rpcs: HashMap<u64, Vec<String>>,
+}
+
+impl Feeds {
+    async fn get_prices(&self, params: serde_json::Value) -> Option<i128> {
+        let network = params["network"].as_u64().unwrap();
+        let currency = params["currency"].as_str().unwrap().to_string();
+        let token = params["token"].as_str().unwrap().to_string();
+        let feeds = &self.feeds[&(network, currency.clone(), token.clone())];
+        let rpcs = &self.rpcs[&network];
+        for feed in feeds {
+            if let Some(res) = feed.get_feed_price(rpcs).await {
+                return Some(res)
+            }
+        }
+        None
+    }
 }


### PR DESCRIPTION
Fixes #310.

Adds RPCs endpoints and creates a command to query the price feeds for a specific token in a specific currency.