### PR TITLE
Fix starting issue related to React Suspense

### DIFF
--- a/gui/src/routes/__root.tsx
+++ b/gui/src/routes/__root.tsx
@@ -40,8 +40,8 @@ function Root() {
       <CssBaseline>
         <ErrorHandler>
           <QueryClientProvider client={queryClient}>
-            <DevBuildNotice />
             <Suspense>
+              <DevBuildNotice />
               <Outlet />
             </Suspense>
 


### PR DESCRIPTION
Why:
* The `DevBuildNotice` component is using the `useInvoke` hook, that makes
  use of React Suspense, but the component wasn't wrapped around a
  `Suspense` component, causing the error to appear

How:
* Moving the `DevBuildNotice` component to be inside the `Suspense`
  component in the component tree
