### PR TITLE
Change Sign Message dialog UI

### DIFF
--- a/crates/dialogs/src/presets.rs
+++ b/crates/dialogs/src/presets.rs
@@ -24,8 +24,8 @@ pub(super) static PRESETS: Lazy<HashMap<String, Preset>> = Lazy::new(|| {
         "msg-sign".into(),
         Preset {
             title: "Sign Message".into(),
-            w: 400.0,
-            h: 220.0,
+            w: 600.0,
+            h: 600.0,
         },
     );
 

--- a/gui/src/routes/_dialog.dialog/msg-sign.$id.tsx
+++ b/gui/src/routes/_dialog.dialog/msg-sign.$id.tsx
@@ -1,9 +1,9 @@
-import { Button, Stack, Typography } from "@mui/material";
+import { Button, Stack } from "@mui/material";
 import { Delete, Task } from "@mui/icons-material";
 import { createFileRoute } from "@tanstack/react-router";
 
+import { HighlightBox, Typography } from "@ethui/react/components";
 import { useDialog } from "@/hooks";
-import { DialogBottom } from "@/components/Dialogs/Bottom";
 
 export const Route = createFileRoute("/_dialog/dialog/msg-sign/$id")({
   component: MsgSignDialog,
@@ -18,34 +18,55 @@ export function MsgSignDialog() {
   const msg = data["Raw"] || JSON.stringify(data["Typed"], null, 2);
 
   return (
-    <>
+    <Stack
+      sx={{
+        height: "100%",
+        gap: "15px",
+      }}
+    >
       <Typography variant="h6" component="h1">
         Sign Message
       </Typography>
-      <Typography>{msg}</Typography>
-
-      <DialogBottom>
-        <Stack direction="row" justifyContent="center" spacing={2}>
-          <Button
-            size="large"
-            variant="contained"
-            color="error"
-            onClick={() => send("reject")}
-            startIcon={<Delete />}
-          >
-            Reject
-          </Button>
-          <Button
-            size="large"
-            variant="contained"
-            type="submit"
-            onClick={() => send("accept")}
-            endIcon={<Task />}
-          >
-            Sign
-          </Button>
-        </Stack>
-      </DialogBottom>
-    </>
+      {msg && (
+        <HighlightBox
+          fullWidth
+          sx={{
+            overflowY: "auto",
+            minHeight: 100,
+          }}
+        >
+          <Typography whiteSpace="pre-wrap" variant="body2" mono>
+            {msg}
+          </Typography>
+        </HighlightBox>
+      )}
+      <Stack
+        direction="row"
+        justifyContent="center"
+        spacing={2}
+        marginTop="auto"
+      >
+        <Button
+          disabled={!msg}
+          size="large"
+          variant="contained"
+          color="error"
+          onClick={() => send("reject")}
+          startIcon={<Delete />}
+        >
+          Reject
+        </Button>
+        <Button
+          disabled={!msg}
+          size="large"
+          variant="contained"
+          type="submit"
+          onClick={() => send("accept")}
+          endIcon={<Task />}
+        >
+          Sign
+        </Button>
+      </Stack>
+    </Stack>
   );
 }


### PR DESCRIPTION
This PR introduces a simple enhancement to the Sign Message dialog. It now includes a box that displays the message, formatting JSON for better readability. Additionally, I resized the dialog window to accommodate larger messages, particularly JSON. The images below illustrate examples of a raw message and a JSON message.

<div>
  <img width="300" alt="Screenshot 2024-06-19 at 16 17 08" src="https://github.com/ethui/ethui/assets/20384134/9fb2717d-980a-4abe-a296-68dc2c8806a2">
  <img width="320" alt="Screenshot 2024-06-19 at 13 03 18" src="https://github.com/ethui/ethui/assets/20384134/d9780f27-cea9-49ea-8482-ff4d47fcd1b3">
</div>
