### PR TITLE
fix: Return value of view functions

### DIFF
--- a/gui/src/components/ABIForm/ABIItemForm.tsx
+++ b/gui/src/components/ABIForm/ABIItemForm.tsx
@@ -91,7 +91,7 @@ export function ABIItemForm({
         />
 
         {result && "read" in result && (
-          <Typography mono>{result.toString()}</Typography>
+          <Typography mono>{result.read.toString()}</Typography>
         )}
         {result && "write" in result && <HashView hash={result.write} />}
       </Grid>


### PR DESCRIPTION
Why:
* Calling a view function on a contract would display as `[object
  Object]` instead of the actual return value

before:
<img width="834" alt="image" src="https://github.com/ethui/ethui/assets/2940022/01a5b191-96be-41b9-be9a-7cf33191f2f3">

after:
<img width="834" alt="image" src="https://github.com/ethui/ethui/assets/2940022/cd1f3332-6252-4d22-812d-508cc33855c1">
