### PR TITLE
Add NumberView and HashView components

### DIFF
--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -8,7 +8,6 @@ import { useNetworks } from "@/store";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { truncateHex } from "@/utils";
 
-
 interface Props {
   hash: Hash;
 }

--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -13,30 +13,20 @@ interface Props {
 }
 
 export function HashView({ hash }: Props) {
-  const [displayValue] = useState(hash.toString());
-  const [decimalValue, setDecimalValue] = useState('');
+  const [decimalValue, setDecimalValue] = useState("");
   const [unitValuesOpen, setUnitValuesOpen] = useState(false);
 
-
   useEffect(() => {
-    convertToDecimal(hash);
+    setDecimalValue(BigInt(hash).toString(10));
   }, [hash]);
-
-  const convertToDecimal = (hash: string | bigint) => {
-
-    const decimalValue = BigInt(hash).toString(10);
-    setDecimalValue(decimalValue);
-
-  };
-
 
   const content = (
     <Grid container rowSpacing={1} columns={1}>
       <Datapoint
         label="Hexadecimal"
         value={
-          <ContextMenuWithTauri copy={displayValue}>
-            {truncateHex(displayValue)}
+          <ContextMenuWithTauri copy={hash}>
+            {truncateHex(hash)}
           </ContextMenuWithTauri>
         }
         size="small"
@@ -56,8 +46,8 @@ export function HashView({ hash }: Props) {
   return (
     <Stack direction="row">
       <div style={{ display: "flex", alignItems: "center" }}>
-        <ContextMenuWithTauri copy={displayValue}>
-          {truncateHex(displayValue)}
+        <ContextMenuWithTauri copy={hash}>
+          {truncateHex(hash)}
         </ContextMenuWithTauri>
 
         <IconButton

--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -1,33 +1,72 @@
 import { Hash } from "viem";
+import { useState } from "react";
 
 import { Typography } from "@ethui/react/components";
 import { useNetworks } from "@/store";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { truncateHex } from "@/utils";
+import { IconButton, Menu, MenuItem } from "@mui/material";
+import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 
 interface Props {
   hash: Hash;
 }
 
 export function HashView({ hash }: Props) {
-  const network = useNetworks((s) => s.current);
+  const [displayValue, setDisplayValue] = useState(hash.toString());
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
 
+  const network = useNetworks((s) => s.current);
   if (!network) return null;
 
-  const content = <Typography mono>{truncateHex(hash)}</Typography>;
+  const changeFormat = () => {
+    const valueToString = displayValue.toString();
+
+    const isHexadecimal = /^0x[0-9a-fA-F]+$/.test(valueToString);
+    const isDecimal = /^([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)$/.test(
+      valueToString
+    );
+
+    if (isHexadecimal) {
+      const decimalValue = BigInt(valueToString);
+      setDisplayValue(decimalValue.toString());
+    } else if (isDecimal) {
+      setDisplayValue(hash.toString());
+    } else {
+      setDisplayValue("Invalid");
+    }
+    setMenuAnchor(null);
+  };
+
+  const content = <Typography mono>{truncateHex(displayValue)}</Typography>;
+
+  const onMenuOpen = (event: React.MouseEvent<HTMLElement>) =>
+    setMenuAnchor(event.currentTarget);
 
   return (
-    <ContextMenuWithTauri
-      copy={hash}
-      actions={[
-        {
-          label: "Open in explorer",
-          href: `${network.explorer_url}${hash}`,
-          disabled: !network.explorer_url,
-        },
-      ]}
-    >
-      {content}
-    </ContextMenuWithTauri>
+    <>
+      <ContextMenuWithTauri
+        copy={displayValue}
+        actions={[
+          {
+            label: "Open in explorer",
+            href: `${network.explorer_url}${displayValue}`,
+            disabled: !network.explorer_url,
+          },
+        ]}
+      >
+        {content}
+        <IconButton aria-label="more" onClick={onMenuOpen}>
+          <MoreVertIcon />
+        </IconButton>
+      </ContextMenuWithTauri>
+      <Menu
+        open={Boolean(menuAnchor)}
+        anchorEl={menuAnchor}
+        onClose={() => setMenuAnchor(null)}
+      >
+        <MenuItem onClick={changeFormat}>Change Format</MenuItem>
+      </Menu>
+    </>
   );
 }

--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -1,12 +1,12 @@
+import { IconButton, Menu, MenuItem } from "@mui/material";
+import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { Hash } from "viem";
 import { useState } from "react";
-
 import { Typography } from "@ethui/react/components";
 import { useNetworks } from "@/store";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { truncateHex } from "@/utils";
-import { IconButton, Menu, MenuItem } from "@mui/material";
-import { MoreVert as MoreVertIcon } from "@mui/icons-material";
+
 
 interface Props {
   hash: Hash;

--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -1,72 +1,76 @@
-import { IconButton, Menu, MenuItem } from "@mui/material";
+import { Grid, IconButton, Stack } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { Hash } from "viem";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import { Typography } from "@ethui/react/components";
-import { useNetworks } from "@/store";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { truncateHex } from "@/utils";
+import { Datapoint } from "./Datapoint";
+import { Modal } from "./Modal";
 
 interface Props {
   hash: Hash;
 }
 
 export function HashView({ hash }: Props) {
-  const [displayValue, setDisplayValue] = useState(hash.toString());
-  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [displayValue] = useState(hash.toString());
+  const [decimalValue, setDecimalValue] = useState('');
+  const [unitValuesOpen, setUnitValuesOpen] = useState(false);
 
-  const network = useNetworks((s) => s.current);
-  if (!network) return null;
 
-  const changeFormat = () => {
-    const valueToString = displayValue.toString();
+  useEffect(() => {
+    convertToDecimal(hash);
+  }, [hash]);
 
-    const isHexadecimal = /^0x[0-9a-fA-F]+$/.test(valueToString);
-    const isDecimal = /^([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)$/.test(
-      valueToString
-    );
+  const convertToDecimal = (hash: string | bigint) => {
 
-    if (isHexadecimal) {
-      const decimalValue = BigInt(valueToString);
-      setDisplayValue(decimalValue.toString());
-    } else if (isDecimal) {
-      setDisplayValue(hash.toString());
-    } else {
-      setDisplayValue("Invalid");
-    }
-    setMenuAnchor(null);
+    const decimalValue = BigInt(hash).toString(10);
+    setDecimalValue(decimalValue);
+
   };
 
-  const content = <Typography mono>{truncateHex(displayValue)}</Typography>;
 
-  const onMenuOpen = (event: React.MouseEvent<HTMLElement>) =>
-    setMenuAnchor(event.currentTarget);
+  const content = (
+    <Grid container rowSpacing={1} columns={1}>
+      <Datapoint
+        label="Hexadecimal"
+        value={
+          <ContextMenuWithTauri copy={displayValue}>
+            {truncateHex(displayValue)}
+          </ContextMenuWithTauri>
+        }
+        size="small"
+      />
+      <Datapoint
+        label="Decimal"
+        value={
+          <ContextMenuWithTauri copy={decimalValue}>
+            {truncateHex(decimalValue)}
+          </ContextMenuWithTauri>
+        }
+        size="small"
+      />
+    </Grid>
+  );
 
   return (
-    <>
-      <ContextMenuWithTauri
-        copy={displayValue}
-        actions={[
-          {
-            label: "Open in explorer",
-            href: `${network.explorer_url}${displayValue}`,
-            disabled: !network.explorer_url,
-          },
-        ]}
-      >
-        {content}
-        <IconButton aria-label="more" onClick={onMenuOpen}>
+    <Stack direction="row">
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <ContextMenuWithTauri copy={displayValue}>
+          {truncateHex(displayValue)}
+        </ContextMenuWithTauri>
+
+        <IconButton
+          aria-label="transfer"
+          onClick={() => setUnitValuesOpen(true)}
+        >
           <MoreVertIcon />
         </IconButton>
-      </ContextMenuWithTauri>
-      <Menu
-        open={Boolean(menuAnchor)}
-        anchorEl={menuAnchor}
-        onClose={() => setMenuAnchor(null)}
-      >
-        <MenuItem onClick={changeFormat}>Change Format</MenuItem>
-      </Menu>
-    </>
+
+        <Modal open={unitValuesOpen} onClose={() => setUnitValuesOpen(false)}>
+          {content}
+        </Modal>
+      </div>
+    </Stack>
   );
 }

--- a/gui/src/components/HashView.tsx
+++ b/gui/src/components/HashView.tsx
@@ -2,6 +2,7 @@ import { IconButton, Menu, MenuItem } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { Hash } from "viem";
 import { useState } from "react";
+
 import { Typography } from "@ethui/react/components";
 import { useNetworks } from "@/store";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -1,4 +1,4 @@
-import { Grid, IconButton, Popover, Stack, Tooltip } from "@mui/material";
+import { Grid, IconButton, Popover, Stack } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import { formatUnits, parseUnits } from "viem";
@@ -12,7 +12,9 @@ interface Props {
 }
 
 export function NumberView({ value, unit }: Props) {
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [anchorEl, setAnchorEl] = useState<{
+    [key: string]: HTMLElement | null;
+  }>({});
   const [unitValuesOpen, setUnitValuesOpen] = useState(false);
   const [conversionResults, setConversionResults] = useState<{
     [key: string]: string | bigint;
@@ -29,30 +31,25 @@ export function NumberView({ value, unit }: Props) {
     }
   }, [value, unit]);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    unit: string
+  ) => {
+    setAnchorEl((prev) => ({ ...prev, [unit]: event.currentTarget }));
   };
 
-  const handleClose = () => {
-    setAnchorEl(null);
+  const handleClose = (unit: string) => {
+    setAnchorEl((prev) => ({ ...prev, [unit]: null }));
   };
-
-  const open = Boolean(anchorEl);
 
   const unitMapping: { [key: string]: number } = {
     wei: 0,
     kwei: 3,
-    babbage: 3,
     mwei: 6,
-    lovelace: 6,
     gwei: 9,
-    shannon: 9,
     microether: 12,
-    szabo: 12,
     milliether: 15,
-    finney: 15,
     ether: 18,
-    eth: 18,
   };
 
   function convertUnits(val: bigint, fromUnit: string, toUnit: string): string {
@@ -85,28 +82,30 @@ export function NumberView({ value, unit }: Props) {
   const content = (
     <Grid container spacing={2}>
       {Object.keys(conversionResults).map((unit) => (
-        <Grid item xs={12} sm={6} md={4} lg={3} key={unit}>
+        <Grid item xs={12} sm={6} key={unit}>
           <Datapoint
             label={unit}
             value={
-              <div style={{ display: "flex", alignItems: "center" }} key={unit}>
+              <div style={{ display: "flex", alignItems: "center" }}>
                 <ContextMenuWithTauri copy={conversionResults[unit]}>
                   {conversionResults[unit].toString()}
                 </ContextMenuWithTauri>
-                <IconButton aria-label="transfer" onClick={handleClick}>
+                <IconButton
+                  aria-label="transfer"
+                  onClick={(event) => handleClick(event, unit)}
+                >
                   <MoreVertIcon />
                 </IconButton>
                 <Popover
-                  key={unit}
-                  open={open}
-                  anchorEl={anchorEl}
-                  onClose={handleClose}
+                  open={Boolean(anchorEl[unit])}
+                  anchorEl={anchorEl[unit]}
+                  onClose={() => handleClose(unit)}
                   anchorOrigin={{
                     vertical: "bottom",
                     horizontal: "left",
                   }}
                 >
-                  <Grid container key={unit} rowSpacing={1} columns={1} sx={{ p: 2 }}>
+                  <Grid container rowSpacing={1} columns={1} sx={{ p: 2 }}>
                     <Datapoint
                       label="hexadecimal"
                       value={

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -7,16 +7,14 @@ import { Typography } from "@ethui/react/components";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { useNetworks } from "@/store";
 
-
-
 interface Props {
   value: number;
 }
 
-export function NumberView({ value}: Props) {
+export function NumberView({ value }: Props) {
   const [displayValue, setDisplayValue] = useState(value.toString());
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
-  const [formatValue, setFormatValue] = useState('Hexadecimal');
+  const [formatValue, setFormatValue] = useState("Hexadecimal");
 
   const network = useNetworks((s) => s.current);
   if (!network) return null;
@@ -37,25 +35,20 @@ export function NumberView({ value}: Props) {
     setMenuAnchor(null);
   };
 
-
-
-const changeFormat = () => {
-  if (formatValue == 'Decimal') {
-    setFormatValue('Hexadecimal');
-    setDisplayValue(value.toString());
-
-  } else if (formatValue == 'Hexadecimal') {
-    setFormatValue('Decimal');
-    const numberValue = Number(value);
-    const hexadecimalValue = numberValue.toString(16).toUpperCase();
-    setDisplayValue('0x' + hexadecimalValue);
-
-  } else {
-    setDisplayValue(value.toString());
-  }
-  setMenuAnchor(null);
-};
-
+  const changeFormat = () => {
+    if (formatValue == "Decimal") {
+      setFormatValue("Hexadecimal");
+      setDisplayValue(value.toString());
+    } else if (formatValue == "Hexadecimal") {
+      setFormatValue("Decimal");
+      const numberValue = Number(value);
+      const hexadecimalValue = numberValue.toString(16).toUpperCase();
+      setDisplayValue("0x" + hexadecimalValue);
+    } else {
+      setDisplayValue(value.toString());
+    }
+    setMenuAnchor(null);
+  };
 
   const content = <Typography mono>{displayValue}</Typography>;
 

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -2,6 +2,7 @@ import { IconButton, Menu, MenuItem } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { useState } from "react";
 import { formatEther, formatGwei, parseEther } from "viem";
+
 import { Typography } from "@ethui/react/components";
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { useNetworks } from "@/store";

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { formatEther, formatGwei, parseEther, parseGwei } from "viem";
 
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
-
 import { Modal } from "./Modal";
 import { Datapoint } from "./Datapoint";
 
@@ -25,98 +24,24 @@ export function NumberView({ value, unit }: Props) {
   const [unitValuesOpen, setUnitValuesOpen] = useState(false);
 
   useEffect(() => {
-    switch (unit) {
-      case "wei":
-        convertFromWei(value);
-        break;
-      case "gwei":
-        convertFromGwei(value);
-        break;
-      case "eth":
-        convertFromEther(value);
-        break;
-      case "decimal":
-        convertFromDecimal(value);
-        break;
-      case "hex":
-        convertFromHex(value);
-        break;
-      default:
-        convertFromDecimal(value);
-        break;
-    }
+    convertUnit(value, unit || "decimal");
   }, [value, unit]);
 
-  const convertFromWei = (value: string | bigint) => {
-    const weiValue = BigInt(value);
+  const convertUnit = (value: string | bigint, unit: string) => {
+    const bigIntValue = BigInt(value);
+    const weiValue =
+      unit === "wei"
+        ? bigIntValue
+        : unit === "gwei"
+          ? parseGwei(bigIntValue.toString(), "wei")
+          : unit === "eth"
+            ? parseEther(bigIntValue.toString(), "wei")
+            : bigIntValue;
+
     const gweiValue = formatGwei(weiValue);
     const ethValue = formatEther(weiValue);
     const decimalValue = weiValue.toString(10);
-    const hexValue = '0x' + weiValue.toString(16);
-
-    setUnitValues({
-      wei: weiValue.toString(),
-      gwei: gweiValue,
-      eth: ethValue,
-      decimal: decimalValue,
-      hex: hexValue,
-    });
-  };
-
-  const convertFromGwei = (value: string | bigint) => {
-    const gweiValue = BigInt(value);
-    const weiValue = parseGwei(gweiValue.toString(), "wei");
-    const ethValue = formatEther(BigInt(value), "gwei"); 
-    const decimalValue = gweiValue.toString(10);
-    const hexValue = '0x' + gweiValue.toString(16);
-
-    setUnitValues({
-      wei: weiValue.toString(),
-      gwei: gweiValue.toString(),
-      eth: ethValue,
-      decimal: decimalValue,
-      hex: hexValue,
-    });
-  };
-
-  const convertFromEther = (value: string | bigint) => {
-    const weiValue = parseEther(value.toString(), "wei");
-    const gweiValue = parseEther(value.toString(), "gwei");
-    const ethValue = value.toString();
-    const decimalValue = value.toString(10);
-    const hexValue = '0x' + value.toString(16);
-
-    setUnitValues({
-      wei: weiValue.toString(),
-      gwei: gweiValue.toString(),
-      eth: ethValue,
-      decimal: decimalValue,
-      hex: hexValue,
-    });
-  };
-
-  const convertFromDecimal = (value: string | bigint) => {
-    const weiValue = BigInt(value);
-    const gweiValue = formatGwei(weiValue);
-    const ethValue = formatEther(weiValue);
-    const decimalValue = weiValue.toString(10);
-    const hexValue = '0x' + weiValue.toString(16);
-
-    setUnitValues({
-      wei: weiValue.toString(),
-      gwei: gweiValue,
-      eth: ethValue,
-      decimal: decimalValue,
-      hex: hexValue,
-    });
-  };
-
-  const convertFromHex = (value: string | bigint) => {
-    const weiValue = BigInt(value);
-    const gweiValue = formatGwei(weiValue);
-    const ethValue = formatEther(weiValue);
-    const decimalValue = weiValue.toString(10);
-    const hexValue = '0x' + weiValue.toString(16);
+    const hexValue = "0x" + weiValue.toString(16);
 
     setUnitValues({
       wei: weiValue.toString(),
@@ -138,7 +63,6 @@ export function NumberView({ value, unit }: Props) {
         }
         size="small"
       />
-
       <Datapoint
         label="Wei"
         value={
@@ -184,14 +108,12 @@ export function NumberView({ value, unit }: Props) {
         <ContextMenuWithTauri copy={value}>
           {value.toString()}
         </ContextMenuWithTauri>
-
         <IconButton
           aria-label="transfer"
           onClick={() => setUnitValuesOpen(true)}
         >
           <MoreVertIcon />
         </IconButton>
-
         <Modal open={unitValuesOpen} onClose={() => setUnitValuesOpen(false)}>
           {content}
         </Modal>

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -2,6 +2,7 @@ import { Grid, IconButton, Popover, Stack } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import { formatUnits, parseUnits } from "viem";
+
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { Modal } from "./Modal";
 import { Datapoint } from ".";

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -1,18 +1,21 @@
-import { useState } from "react";
-import { useNetworks } from "@/store";
-import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
-import { Typography } from "@ethui/react/components";
 import { IconButton, Menu, MenuItem } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
+import { useState } from "react";
 import { formatEther, formatGwei, parseEther } from "viem";
+import { Typography } from "@ethui/react/components";
+import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
+import { useNetworks } from "@/store";
+
+
 
 interface Props {
   value: number;
 }
 
 export function NumberView({ value}: Props) {
-  const [displayValue, setDisplayValue] = useState(formatEther(BigInt(value)) + ' eth');
+  const [displayValue, setDisplayValue] = useState(value.toString());
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [formatValue, setFormatValue] = useState('Hexadecimal');
 
   const network = useNetworks((s) => s.current);
   if (!network) return null;
@@ -34,25 +37,23 @@ export function NumberView({ value}: Props) {
   };
 
 
-  const changeFormat = () => {
-    const newValue = displayValue.split(' ')[0];
-    const isHexadecimal = /^(.*[A-Za-z])[0-9A-Za-z]*$/.test(newValue);
-    const isDecimal = /^([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)$/.test(newValue);
 
-    if (isHexadecimal) {
-      setDisplayValue(formatEther(BigInt(value)) + ' eth');
-  
-    } else if (isDecimal) {
-      const numberValue = Number(newValue);
-      const hexadecimalValue = numberValue.toString(16).toUpperCase();
-      setDisplayValue('0x' + hexadecimalValue + " " + displayValue.split(' ')[1]);
-  
-    } else {
-      setDisplayValue(newValue);
-    }
-    setMenuAnchor(null);
-  };
-  
+const changeFormat = () => {
+  if (formatValue == 'Decimal') {
+    setFormatValue('Hexadecimal');
+    setDisplayValue(value.toString());
+
+  } else if (formatValue == 'Hexadecimal') {
+    setFormatValue('Decimal');
+    const numberValue = Number(value);
+    const hexadecimalValue = numberValue.toString(16).toUpperCase();
+    setDisplayValue('0x' + hexadecimalValue);
+
+  } else {
+    setDisplayValue(value.toString());
+  }
+  setMenuAnchor(null);
+};
 
 
   const content = <Typography mono>{displayValue}</Typography>;
@@ -83,7 +84,7 @@ export function NumberView({ value}: Props) {
         <MenuItem onClick={formatWeiValue}>Wei</MenuItem>
         <MenuItem onClick={formatGweiValue}>Gwei</MenuItem>
         <MenuItem onClick={formatEtherValue}>Ether</MenuItem>
-        <MenuItem onClick={changeFormat}>Change Format</MenuItem>
+        <MenuItem onClick={changeFormat}>Change to {formatValue}</MenuItem>
       </Menu>
     </div>
   );

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -1,8 +1,7 @@
-import { Box, Grid, IconButton, Stack, Typography } from "@mui/material";
+import { Grid, IconButton, Popover, Stack, Tooltip } from "@mui/material";
 import { MoreVert as MoreVertIcon } from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import { formatUnits, parseUnits } from "viem";
-
 import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
 import { Modal } from "./Modal";
 import { Datapoint } from ".";
@@ -13,6 +12,7 @@ interface Props {
 }
 
 export function NumberView({ value, unit }: Props) {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [unitValuesOpen, setUnitValuesOpen] = useState(false);
   const [conversionResults, setConversionResults] = useState<{
     [key: string]: string | bigint;
@@ -28,6 +28,16 @@ export function NumberView({ value, unit }: Props) {
       setConversionResults({});
     }
   }, [value, unit]);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
 
   const unitMapping: { [key: string]: number } = {
     wei: 0,
@@ -67,6 +77,11 @@ export function NumberView({ value, unit }: Props) {
     return results;
   }
 
+  const convertToHex = (value: string | bigint) => {
+    const bigintValue = BigInt(value);
+    return "0x" + bigintValue.toString(16);
+  };
+
   const content = (
     <Grid container spacing={2}>
       {Object.keys(conversionResults).map((unit) => (
@@ -74,9 +89,47 @@ export function NumberView({ value, unit }: Props) {
           <Datapoint
             label={unit}
             value={
-              <ContextMenuWithTauri copy={conversionResults[unit]}>
-                {conversionResults[unit].toString()}
-              </ContextMenuWithTauri>
+              <div style={{ display: "flex", alignItems: "center" }} key={unit}>
+                <ContextMenuWithTauri copy={conversionResults[unit]}>
+                  {conversionResults[unit].toString()}
+                </ContextMenuWithTauri>
+                <IconButton aria-label="transfer" onClick={handleClick}>
+                  <MoreVertIcon />
+                </IconButton>
+                <Popover
+                  key={unit}
+                  open={open}
+                  anchorEl={anchorEl}
+                  onClose={handleClose}
+                  anchorOrigin={{
+                    vertical: "bottom",
+                    horizontal: "left",
+                  }}
+                >
+                  <Grid container key={unit} rowSpacing={1} columns={1} sx={{ p: 2 }}>
+                    <Datapoint
+                      label="hexadecimal"
+                      value={
+                        <ContextMenuWithTauri
+                          copy={convertToHex(conversionResults[unit])}
+                        >
+                          {convertToHex(conversionResults[unit])}
+                        </ContextMenuWithTauri>
+                      }
+                      size="small"
+                    />
+                    <Datapoint
+                      label="decimal"
+                      value={
+                        <ContextMenuWithTauri copy={conversionResults[unit]}>
+                          {conversionResults[unit].toString()}
+                        </ContextMenuWithTauri>
+                      }
+                      size="small"
+                    />
+                  </Grid>
+                </Popover>
+              </div>
             }
             size="small"
           />

--- a/gui/src/components/NumberView.tsx
+++ b/gui/src/components/NumberView.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { useNetworks } from "@/store";
+import { ContextMenuWithTauri } from "./ContextMenuWithTauri";
+import { Typography } from "@ethui/react/components";
+import { IconButton, Menu, MenuItem } from "@mui/material";
+import { MoreVert as MoreVertIcon } from "@mui/icons-material";
+import { formatEther, formatGwei, parseEther } from "viem";
+
+interface Props {
+  value: number;
+}
+
+export function NumberView({ value}: Props) {
+  const [displayValue, setDisplayValue] = useState(formatEther(BigInt(value)) + ' eth');
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+
+  const network = useNetworks((s) => s.current);
+  if (!network) return null;
+
+  const formatGweiValue = () => {
+    setDisplayValue(formatGwei(BigInt(value)) + " gwei");
+    setMenuAnchor(null);
+  };
+
+  const formatWeiValue = () => {
+    const weiValue = parseEther(formatEther(BigInt(value)).toString());
+    setDisplayValue(weiValue.toString() + " wei");
+    setMenuAnchor(null);
+  };
+
+  const formatEtherValue = () => {
+    setDisplayValue(formatEther(BigInt(value)) + " eth");
+    setMenuAnchor(null);
+  };
+
+
+  const changeFormat = () => {
+    const newValue = displayValue.split(' ')[0];
+    const isHexadecimal = /^(.*[A-Za-z])[0-9A-Za-z]*$/.test(newValue);
+    const isDecimal = /^([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)$/.test(newValue);
+
+    if (isHexadecimal) {
+      setDisplayValue(formatEther(BigInt(value)) + ' eth');
+  
+    } else if (isDecimal) {
+      const numberValue = Number(newValue);
+      const hexadecimalValue = numberValue.toString(16).toUpperCase();
+      setDisplayValue('0x' + hexadecimalValue + " " + displayValue.split(' ')[1]);
+  
+    } else {
+      setDisplayValue(newValue);
+    }
+    setMenuAnchor(null);
+  };
+  
+
+
+  const content = <Typography mono>{displayValue}</Typography>;
+
+  const onMenuOpen = (event: React.MouseEvent<HTMLElement>) =>
+    setMenuAnchor(event.currentTarget);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <ContextMenuWithTauri
+        copy={displayValue}
+        actions={[
+          {
+            label: "Open in explorer",
+            href: `${network.explorer_url}${displayValue}`,
+            disabled: !network.explorer_url,
+          },
+        ]}
+      >
+        {content}
+      </ContextMenuWithTauri>
+
+      <IconButton aria-label="more" onClick={onMenuOpen}>
+        <MoreVertIcon />
+      </IconButton>
+
+      <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)}>
+        <MenuItem onClick={formatWeiValue}>Wei</MenuItem>
+        <MenuItem onClick={formatGweiValue}>Gwei</MenuItem>
+        <MenuItem onClick={formatEtherValue}>Ether</MenuItem>
+        <MenuItem onClick={changeFormat}>Change Format</MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -168,7 +168,6 @@ function Details({ tx, chainId }: DetailsProps) {
   });
 
   if (!fullTx) return null;
-  console.log(JSON.stringify(fullTx));
   const value = BigInt(fullTx.value || 0);
 
   return (

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -97,7 +97,7 @@ export function Txs() {
                 <Details tx={tx} chainId={chainId} />
               </AccordionDetails>
             </Accordion>
-          )),
+          ))
         )}
       </InfiniteScroll>
     </>
@@ -185,7 +185,7 @@ function Details({ tx, chainId }: DetailsProps) {
       />
       <Datapoint
         label="value"
-        value={fullTx.value ? <NumberView value={Number(fullTx.value)}/> : 0}
+        value={fullTx.value ? <NumberView value={Number(fullTx.value)} /> : 0}
         size="small"
       />
       <Datapoint
@@ -219,24 +219,40 @@ function Details({ tx, chainId }: DetailsProps) {
         <>
           <Datapoint
             label="maxFeePerGas"
-            value={fullTx.maxFeePerGas ? <NumberView value={Number(fullTx.maxFeePerGas)}/> : 0}
+            value={
+              fullTx.maxFeePerGas ? (
+                <NumberView value={Number(fullTx.maxFeePerGas)} />
+              ) : (
+                0
+              )
+            }
             size="small"
           />
           <Datapoint
             label="maxPriorityFeePerGas"
-            value={fullTx.maxPriorityFeePerGas ? <NumberView value={Number(fullTx.maxPriorityFeePerGas)}/> : 0}
+            value={
+              fullTx.maxPriorityFeePerGas ? (
+                <NumberView value={Number(fullTx.maxPriorityFeePerGas)} />
+              ) : (
+                0
+              )
+            }
             size="small"
           />
         </>
       )}
       <Datapoint
         label="gasLimit"
-        value={fullTx.gasLimit ? <NumberView value={Number(fullTx.gasLimit)}/> : 0}
+        value={
+          fullTx.gasLimit ? <NumberView value={Number(fullTx.gasLimit)} /> : 0
+        }
         size="small"
       />
       <Datapoint
         label="gasUsed"
-        value={fullTx.gasUsed ? <NumberView value={Number(fullTx.gasUsed)}/> : 0}
+        value={
+          fullTx.gasUsed ? <NumberView value={Number(fullTx.gasUsed)} /> : 0
+        }
         size="medium"
       />
 

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -168,7 +168,7 @@ function Details({ tx, chainId }: DetailsProps) {
   });
 
   if (!fullTx) return null;
-
+  console.log(JSON.stringify(fullTx));
   const value = BigInt(fullTx.value || 0);
 
   return (
@@ -185,7 +185,7 @@ function Details({ tx, chainId }: DetailsProps) {
       />
       <Datapoint
         label="value"
-        value={fullTx.value ? <NumberView value={Number(fullTx.value)} /> : 0}
+        value={fullTx.value ? <NumberView value={fullTx.value}/> : 0}
         size="small"
       />
       <Datapoint
@@ -221,7 +221,7 @@ function Details({ tx, chainId }: DetailsProps) {
             label="maxFeePerGas"
             value={
               fullTx.maxFeePerGas ? (
-                <NumberView value={Number(fullTx.maxFeePerGas)} />
+                <NumberView value={fullTx.maxFeePerGas} unit="gwei"/>
               ) : (
                 0
               )
@@ -232,7 +232,7 @@ function Details({ tx, chainId }: DetailsProps) {
             label="maxPriorityFeePerGas"
             value={
               fullTx.maxPriorityFeePerGas ? (
-                <NumberView value={Number(fullTx.maxPriorityFeePerGas)} />
+                <NumberView value={fullTx.maxPriorityFeePerGas} unit="gwei" />
               ) : (
                 0
               )
@@ -244,14 +244,14 @@ function Details({ tx, chainId }: DetailsProps) {
       <Datapoint
         label="gasLimit"
         value={
-          fullTx.gasLimit ? <NumberView value={Number(fullTx.gasLimit)} /> : 0
+          fullTx.gasLimit ? <NumberView value={fullTx.gasLimit} unit="wei"/> : 0
         }
         size="small"
       />
       <Datapoint
         label="gasUsed"
         value={
-          fullTx.gasUsed ? <NumberView value={Number(fullTx.gasUsed)} /> : 0
+          fullTx.gasUsed ? <NumberView value={fullTx.gasUsed} unit="wei" /> : 0
         }
         size="medium"
       />

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -11,7 +11,7 @@ import {
 import { invoke } from "@tauri-apps/api";
 import { createElement, useCallback, useEffect, useState } from "react";
 import InfiniteScroll from "react-infinite-scroller";
-import { Abi, Address, formatGwei } from "viem";
+import { Abi, Address } from "viem";
 import { createLazyFileRoute } from "@tanstack/react-router";
 
 import { BlockNumber, SolidityCall } from "@ethui/react/components";

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -11,7 +11,7 @@ import {
 import { invoke } from "@tauri-apps/api";
 import { createElement, useCallback, useEffect, useState } from "react";
 import InfiniteScroll from "react-infinite-scroller";
-import { Abi, Address, formatEther, formatGwei } from "viem";
+import { Abi, Address, formatGwei } from "viem";
 import { createLazyFileRoute } from "@tanstack/react-router";
 
 import { BlockNumber, SolidityCall } from "@ethui/react/components";
@@ -23,11 +23,11 @@ import {
   AccordionDetails,
   AccordionSummary,
   AddressView,
-  ContextMenuWithTauri,
 } from "@/components";
 import { Datapoint } from "@/components/Datapoint";
 import { Navbar } from "@/components/Home/Navbar";
 import { HashView } from "@/components/HashView";
+import { NumberView } from "@/components/NumberView";
 
 export const Route = createLazyFileRoute("/_home/home/transactions")({
   component: Txs,
@@ -185,11 +185,7 @@ function Details({ tx, chainId }: DetailsProps) {
       />
       <Datapoint
         label="value"
-        value={
-          <ContextMenuWithTauri copy={value}>
-            {formatEther(value)} Ξ
-          </ContextMenuWithTauri>
-        }
+        value={fullTx.value ? <NumberView value={Number(fullTx.value)}/> : 0}
         size="small"
       />
       <Datapoint
@@ -223,24 +219,24 @@ function Details({ tx, chainId }: DetailsProps) {
         <>
           <Datapoint
             label="maxFeePerGas"
-            value={`${fullTx.maxFeePerGas && formatGwei(BigInt(fullTx.maxFeePerGas))} gwei`}
+            value={fullTx.maxFeePerGas ? <NumberView value={Number(fullTx.maxFeePerGas)}/> : 0}
             size="small"
           />
           <Datapoint
             label="maxPriorityFeePerGas"
-            value={`${fullTx.maxPriorityFeePerGas && formatGwei(BigInt(fullTx.maxPriorityFeePerGas))} gwei`}
+            value={fullTx.maxPriorityFeePerGas ? <NumberView value={Number(fullTx.maxPriorityFeePerGas)}/> : 0}
             size="small"
           />
         </>
       )}
       <Datapoint
         label="gasLimit"
-        value={fullTx.gasLimit && `${formatGwei(BigInt(fullTx.gasLimit))} gwei`}
+        value={fullTx.gasLimit ? <NumberView value={Number(fullTx.gasLimit)}/> : 0}
         size="small"
       />
       <Datapoint
         label="gasUsed"
-        value={fullTx.gasUsed && `${formatGwei(BigInt(fullTx.gasUsed))} gwei`}
+        value={fullTx.gasUsed ? <NumberView value={Number(fullTx.gasUsed)}/> : 0}
         size="medium"
       />
 

--- a/gui/src/routes/_home.home/transactions.lazy.tsx
+++ b/gui/src/routes/_home.home/transactions.lazy.tsx
@@ -184,7 +184,7 @@ function Details({ tx, chainId }: DetailsProps) {
       />
       <Datapoint
         label="value"
-        value={fullTx.value ? <NumberView value={fullTx.value}/> : 0}
+        value={fullTx.value ? <NumberView value={fullTx.value} unit="wei"/> : 0}
         size="small"
       />
       <Datapoint


### PR DESCRIPTION
**Why:** 

- Currently, it is not possible to convert numbers into different units (wei, gwei, eth) or different formats (decimal to hex)  (Issue #695) 

**How:**
- Added the NumberView and HashView components to enable conversion between units in numbers, copy to clipboard functionality, and format switching between decimal and hex.  
gui/src/components/NumberView.tsx
gui/src/components/HashView.tsx

**Preview**:
![image](https://github.com/ethui/ethui/assets/14261331/46dd8bd6-25d5-49c0-a7b8-5ee2cc5d22c0)
