### PR TITLE
Alchemy Client refactor (Issue #152 - EIP747)

### DIFF
--- a/crates/sync/alchemy/src/lib.rs
+++ b/crates/sync/alchemy/src/lib.rs
@@ -22,11 +22,11 @@ pub struct Alchemy {
 }
 
 impl Alchemy {
-    pub fn new(api_key: &str, db: Db, chain_id: u32) -> Result<Self> {
+    pub fn new(api_key: &str, db: Db, chain_id: u32, path: &str) -> Result<Self> {
         Ok(Self {
             chain_id,
             db,
-            client: Client::new(chain_id, api_key)?,
+            client: Client::new(chain_id, api_key, path)?,
         })
     }
 
@@ -42,10 +42,8 @@ impl Alchemy {
         let key = (self.chain_id, "transactions", address);
         let last_tip: Option<u64> = self.db.kv_get(&key).await?;
 
-
         let from_block = U64::from(last_tip.unwrap_or_else(|| default_from_block(self.chain_id)));
         let latest = self.client.get_block_number().await?;
-        // panic!("\nHello!\n");
 
         // if tip - 1 == latest, we're up to date, nothing to do
         if from_block.saturating_sub(U64::from(1)) == latest {

--- a/crates/sync/alchemy/src/lib.rs
+++ b/crates/sync/alchemy/src/lib.rs
@@ -42,8 +42,10 @@ impl Alchemy {
         let key = (self.chain_id, "transactions", address);
         let last_tip: Option<u64> = self.db.kv_get(&key).await?;
 
+
         let from_block = U64::from(last_tip.unwrap_or_else(|| default_from_block(self.chain_id)));
         let latest = self.client.get_block_number().await?;
+        // panic!("\nHello!\n");
 
         // if tip - 1 == latest, we're up to date, nothing to do
         if from_block.saturating_sub(U64::from(1)) == latest {

--- a/crates/sync/alchemy/src/networks.rs
+++ b/crates/sync/alchemy/src/networks.rs
@@ -17,7 +17,7 @@ pub static NETWORKS: Lazy<HashMap<u32, Network>> = Lazy::new(|| {
     map.insert(
         1,
         Network {
-            base_url: Url::parse("https://eth-mainnet.g.alchemy.com/v2/").unwrap(),
+            base_url: Url::parse("https://eth-mainnet.g.alchemy.com").unwrap(),
             default_from_block: 15537393, // September 15 2022 - The Merge
         },
     );
@@ -25,8 +25,16 @@ pub static NETWORKS: Lazy<HashMap<u32, Network>> = Lazy::new(|| {
     map.insert(
         11155111,
         Network {
-            base_url: Url::parse("https://eth-sepolia.g.alchemy.com/v2/").unwrap(),
+            base_url: Url::parse("https://eth-sepolia.g.alchemy.com").unwrap(),
             default_from_block: 3000000, // May 1st 2023
+        },
+    );
+
+    map.insert(
+        84532,
+        Network {
+            base_url: Url::parse("https://base-sepolia.g.alchemy.com").unwrap(),
+            default_from_block: 1, // September 26th 2023
         },
     );
 
@@ -48,11 +56,11 @@ pub fn default_from_block(chain_id: u32) -> u64 {
         .unwrap_or(0)
 }
 
-pub fn get_endpoint(chain_id: u32, api_key: &str) -> Result<Url> {
+pub fn get_endpoint(chain_id: u32, path: &str, api_key: &str) -> Result<Url> {
     let endpoint = match get_network(&chain_id) {
         Some(network) => network.base_url,
         None => return Err(Error::UnsupportedChainId(chain_id)),
     };
 
-    Ok(endpoint.join(api_key)?)
+    Ok(endpoint.join(path)?.join(api_key)?)
 }

--- a/crates/sync/alchemy/src/networks.rs
+++ b/crates/sync/alchemy/src/networks.rs
@@ -30,14 +30,6 @@ pub static NETWORKS: Lazy<HashMap<u32, Network>> = Lazy::new(|| {
         },
     );
 
-    map.insert(
-        84532,
-        Network {
-            base_url: Url::parse("https://base-sepolia.g.alchemy.com").unwrap(),
-            default_from_block: 1, // September 26th 2023
-        },
-    );
-
     map
 });
 

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -192,7 +192,7 @@ async fn get_alchemy(chain_id: u32) -> Result<ethui_sync_alchemy::Alchemy> {
         Ok(Some(api_key)) => api_key,
         _ => return Err(Error::NoApiKey),
     };
-    let alchemy = ethui_sync_alchemy::Alchemy::new(&api_key, ethui_db::get(), chain_id).unwrap();
+    let alchemy = ethui_sync_alchemy::Alchemy::new(&api_key, ethui_db::get(), chain_id, "").unwrap();
 
     Ok(alchemy)
 }


### PR DESCRIPTION
This PR servers as a needed update to the Alchemy Client to better enable the subsequent implementation of EIP-747.

**Why:**

- At the moment we have a fixed base URL defined under `crates/sync/alchemy/src/networks.rs`. To implement EIP-747, and possibly other proposals down the line, we need a way to dynamically update this URL based on the desired request.
As an example, to fetch an ERC-721 metadata we need to discard the existing `v2/` and replace it with `nft/v3/`.

**How:**

- Refactored the Alchemy Client to accept a string argument to dynamically update the URL as needed:
`crates/sync/alchemy/src/client.rs`
`crates/sync/alchemy/src/lib.rs`

- Functions using this Client now have to create a new instance where they pass the desired string to be added
`crates/sync/alchemy/src/client.rs`
