### PR TITLE
Handle RPC wallet_updateEthereumChain (EIP-2015)

### DIFF
--- a/crates/dialogs/src/presets.rs
+++ b/crates/dialogs/src/presets.rs
@@ -41,9 +41,18 @@ pub(super) static PRESETS: Lazy<HashMap<String, Preset>> = Lazy::new(|| {
     presets.insert(
         "chain-add".into(),
         Preset {
-            title: "Add Chain".into(),
+            title: "Add Network".into(),
             w: 400.0,
             h: 500.0,
+        },
+    );
+
+    presets.insert(
+        "chain-switch".into(),
+        Preset {
+            title: "Switch Network".into(),
+            w: 400.0,
+            h: 350.0,
         },
     );
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -111,6 +111,7 @@ impl Handler {
         self_handler!("eth_signTypedData_v4", Self::eth_sign_typed_data_v4);
         self_handler!("wallet_addEthereumChain", Self::add_chain);
         self_handler!("wallet_switchEthereumChain", Self::switch_chain);
+        self_handler!("wallet_updateEthereumChain", Self::update_chain);
         self_handler!("wallet_watchAsset", Self::add_token);
 
         // metamask
@@ -154,6 +155,18 @@ impl Handler {
     #[tracing::instrument()]
     async fn add_chain(params: Params, ctx: Ctx) -> jsonrpc_core::Result<serde_json::Value> {
         let method = methods::ChainAdd::build()
+            .set_params(params.into())?
+            .build()
+            .await;
+
+        method.run().await?;
+
+        Ok(serde_json::Value::Null)
+    }
+
+    #[tracing::instrument()]
+    async fn update_chain(params: Params, ctx: Ctx) -> jsonrpc_core::Result<serde_json::Value> {
+        let method = methods::ChainUpdate::build()
             .set_params(params.into())?
             .build()
             .await;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -173,7 +173,7 @@ impl Handler {
 
         method.run().await?;
 
-        Ok(serde_json::Value::Null)
+        Ok(true.into())
     }
 
     #[tracing::instrument()]

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -10,7 +10,7 @@ pub struct ChainUpdate {
     network: Network,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize)]
 pub struct NetworkSwitch {
     pub current_id: u32,
     pub current_name: String,
@@ -167,7 +167,6 @@ impl TryFrom<Params> for Network {
 
 impl ChainUpdateBuilder {
     pub fn set_params(mut self, params: serde_json::Value) -> Result<Self> {
-        // TODO: why is this an array?
         let params: serde_json::Value = if params.is_array() {
             params.as_array().unwrap()[0].clone()
         } else {

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -1,0 +1,116 @@
+use ethui_dialogs::{Dialog, DialogMsg};
+use ethui_networks::{Network, Networks};
+use ethui_types::{GlobalState, U64};
+use serde::{Deserialize, Serialize};
+use url::Url;
+use crate::{Error, Result};
+
+#[derive(Debug)]
+pub struct ChainUpdate {
+    network: Network,
+}
+
+impl ChainUpdate {
+    pub fn build() -> ChainUpdateBuilder {
+        ChainUpdateBuilder::default()
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let dialog = Dialog::new("chain-update", serde_json::to_value(&self.network).unwrap());
+        dialog.open().await?;
+
+        if self.already_exists().await {
+
+            return Ok(());
+        }
+
+        while let Some(msg) = dialog.recv().await {
+            match msg {
+                DialogMsg::Data(msg) => {
+                    if let Some("accept") = msg.as_str() {
+                        self.on_accept().await?;
+                        break;
+                    }
+                }
+
+                DialogMsg::Close => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn already_exists(&self) -> bool {
+        let networks = Networks::read().await;
+        networks.validate_chain_id(self.network.chain_id)
+    }
+
+    pub async fn on_accept(&self) -> Result<()> {
+        let mut networks = Networks::write().await;
+        networks.add_network(self.network.clone()).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Params {
+    chain_id: U64,
+    chain_name: String,
+    native_currency: Currency,
+    block_explorer_urls: Vec<Url>,
+    rpc_urls: Vec<Url>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Currency {
+    decimals: u64,
+    name: Option<String>,
+    symbol: String,
+}
+
+#[derive(Default)]
+pub struct ChainUpdateBuilder {
+    params: Option<Params>,
+}
+
+impl TryFrom<Params> for Network {
+    type Error = Error;
+    fn try_from(params: Params) -> Result<Self> {
+        Ok(Self {
+            name: params.chain_name,
+            chain_id: params.chain_id.try_into().unwrap(),
+            explorer_url: params.block_explorer_urls.first().map(|u| u.to_string()),
+            http_url: params
+                .rpc_urls
+                .first()
+                .map(|s| s.to_string())
+                .ok_or(Error::Rpc(-32602))?,
+            ws_url: None,
+            currency: params.native_currency.symbol,
+            decimals: params.native_currency.decimals as u32,
+        })
+    }
+}
+
+impl ChainUpdateBuilder {
+    pub fn set_params(mut self, params: serde_json::Value) -> Result<Self> {
+        // TODO: why is this an array?
+        let params: serde_json::Value = if params.is_array() {
+            params.as_array().unwrap()[0].clone()
+        } else {
+            params
+        };
+
+        self.params = Some(serde_json::from_value(params)?);
+        Ok(self)
+    }
+
+    pub async fn build(self) -> ChainUpdate {
+        ChainUpdate {
+            network: self.params.unwrap().try_into().unwrap(),
+        }
+    }
+}

--- a/crates/rpc/src/methods/mod.rs
+++ b/crates/rpc/src/methods/mod.rs
@@ -1,10 +1,12 @@
 mod chain_add;
+mod chain_update;
 mod token_add;
 mod send_call;
 mod send_transaction;
 mod sign_message;
 
 pub use chain_add::ChainAdd;
+pub use chain_update::ChainUpdate;
 pub use token_add::TokenAdd;
 pub use send_call::SendCall;
 pub use send_transaction::SendTransaction;

--- a/crates/rpc/src/methods/token_add.rs
+++ b/crates/rpc/src/methods/token_add.rs
@@ -96,7 +96,7 @@ impl TokenAdd {
                     Err(Error::ParseError)
                 }
             }
-            _ => return Err(Error::TypeInvalid(self._type.clone())),
+            _ => Err(Error::TypeInvalid(self._type.clone())),
         }
     }
 
@@ -109,9 +109,9 @@ impl TokenAdd {
                         .fetch_erc_owners(erc721_token.address)
                         .await
                         .map_err(|_| Error::ParseError)?;
-                    return Ok(owners_response);
+                    Ok(owners_response)
                 } else {
-                    return Err(Error::ParseError);
+                    Err(Error::ParseError)
                 }
             }
             "ERC1155" => {
@@ -120,12 +120,12 @@ impl TokenAdd {
                         .fetch_erc_owners(erc1155_token.address)
                         .await
                         .map_err(|_| Error::ParseError)?;
-                    return Ok(owners_response);
+                    Ok(owners_response)
                 } else {
-                    return Err(Error::ParseError);
+                    Err(Error::ParseError)
                 }
             }
-            _ => return Err(Error::TypeInvalid(self._type.clone())),
+            _ => Err(Error::TypeInvalid(self._type.clone())),
         }
     }
 
@@ -141,7 +141,7 @@ impl TokenAdd {
                 .collect();
 
             if !owners.contains(&wallet_address.to_string()) {
-                return Err(Error::ErcWrongOwner);
+                Err(Error::ErcWrongOwner)
             } else {
                 for owner in balances_response.owners {
                     if owner.owner_address == wallet_address.to_string() {
@@ -156,7 +156,7 @@ impl TokenAdd {
                         }
                     }
                 }
-                return Err(Error::ErcInvalid);
+                Err(Error::ErcInvalid)
             }
         } else {
             Err(Error::ParseError)
@@ -251,7 +251,7 @@ impl TokenAdd {
             .map(|owner| owner.owner_address.clone())
             .collect();
         if !owners.contains(&wallet_address.to_string()) {
-            return Err(Error::ErcWrongOwner);
+            Err(Error::ErcWrongOwner)
         } else {
             Ok(())
         }

--- a/gui/src/routeTree.gen.ts
+++ b/gui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as DialogDialogMsgSignIdImport } from './routes/_dialog.dialog/ms
 import { Route as DialogDialogErc721AddIdImport } from './routes/_dialog.dialog/erc721-add.$id'
 import { Route as DialogDialogErc20AddIdImport } from './routes/_dialog.dialog/erc20-add.$id'
 import { Route as DialogDialogErc1155AddIdImport } from './routes/_dialog.dialog/erc1155-add.$id'
+import { Route as DialogDialogChainSwitchIdImport } from './routes/_dialog.dialog/chain-switch.$id'
 import { Route as DialogDialogChainAddIdImport } from './routes/_dialog.dialog/chain-add.$id'
 
 // Create Virtual Routes
@@ -110,6 +111,11 @@ const DialogDialogErc1155AddIdRoute = DialogDialogErc1155AddIdImport.update({
   getParentRoute: () => DialogRoute,
 } as any)
 
+const DialogDialogChainSwitchIdRoute = DialogDialogChainSwitchIdImport.update({
+  path: '/dialog/chain-switch/$id',
+  getParentRoute: () => DialogRoute,
+} as any)
+
 const DialogDialogChainAddIdRoute = DialogDialogChainAddIdImport.update({
   path: '/dialog/chain-add/$id',
   getParentRoute: () => DialogRoute,
@@ -175,6 +181,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DialogDialogChainAddIdImport
       parentRoute: typeof DialogImport
     }
+    '/_dialog/dialog/chain-switch/$id': {
+      id: '/_dialog/dialog/chain-switch/$id'
+      path: '/dialog/chain-switch/$id'
+      fullPath: '/dialog/chain-switch/$id'
+      preLoaderRoute: typeof DialogDialogChainSwitchIdImport
+      parentRoute: typeof DialogImport
+    }
     '/_dialog/dialog/erc1155-add/$id': {
       id: '/_dialog/dialog/erc1155-add/$id'
       path: '/dialog/erc1155-add/$id'
@@ -225,6 +238,7 @@ declare module '@tanstack/react-router' {
 export const routeTree = rootRoute.addChildren({
   DialogRoute: DialogRoute.addChildren({
     DialogDialogChainAddIdRoute,
+    DialogDialogChainSwitchIdRoute,
     DialogDialogErc1155AddIdRoute,
     DialogDialogErc20AddIdRoute,
     DialogDialogErc721AddIdRoute,

--- a/gui/src/routes/_dialog.dialog/chain-switch.$id.tsx
+++ b/gui/src/routes/_dialog.dialog/chain-switch.$id.tsx
@@ -1,0 +1,53 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Stack, Typography, Button } from "@mui/material";
+import { isDirty, isValid } from "zod";
+import { window as tauriWindow } from "@tauri-apps/api";
+
+import { NetworkSwitch } from "@ethui/types";
+import { ChainView } from "@ethui/react/components";
+import { useDialog } from "@/hooks";
+
+export const Route = createFileRoute("/_dialog/dialog/chain-switch/$id")({
+  component: ChainSwitchDialog,
+});
+
+export function ChainSwitchDialog() {
+  const { id } = Route.useParams();
+  const { data: network, send } = useDialog<NetworkSwitch>(id);
+
+  if (!network) return null;
+
+  return (
+    <Stack spacing={2} alignItems="center">
+      <Typography variant="h6" component="h1">
+        Switch the network?
+      </Typography>
+
+      <Typography textAlign={"center"}>
+        This will switch the selected network within Ethui to a previously added
+        network:
+      </Typography>
+      <ChainView chainId={network.current_id} name={network.current_name} />
+      <span>↓</span>
+      <ChainView chainId={network.new_id} name={network.new_name} />
+
+      <Stack direction="row" spacing={2} paddingTop={2}>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={() => tauriWindow.appWindow.close()}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          type="submit"
+          disabled={!isDirty || !isValid}
+          onClick={() => send("accept")}
+        >
+          Switch
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -113,4 +113,11 @@ export interface Paginated<T> {
   total: number;
 }
 
+export interface NetworkSwitch {
+  current_id: number;
+  current_name: string;
+  new_id: number;
+  new_name: string;
+}
+
 export type Affinity = { sticky: number } | "global" | "unset";


### PR DESCRIPTION
This PR adds a new method and dialogs to handle the `wallet_updateEthereumChain` RPC, as defined in [EIP-2015](https://eips.ethereum.org/EIPS/eip-2015), in response to #151.

**Why:**

- To allow the switch to a network, and registering it with the wallet if it isn’t already recognized..

**How:**

It handles three scenarios:
1. Network is already active -> returns `true`.
2. Network is recognized -> prompts the user to switch and if accepted returns `true`.
3. Network is not recognized -> prompts the user to add the network and if accepted also prompts the user to switch. If the switch is accepted it returns `true`.

- Added a new RPC method that will manage the call and act according to the scenario found. 
`crates/rpc/src/methods/chain_update.rs`
`crates/rpc/src/methods/mod.rs`
`crates/rpc/src/lib.rs`

- Added new dialogs to prompt the user to accept/reject the network switch.
`crates/dialogs/src/presets.rs`
`gui/src/routes/_dialog.dialog/chain-switch.$id.tsx`
`gui/src/routeTree.gen.ts`
`packages/types/index.ts`

- Clippy fixes on `token-add`
`crates/rpc/src/methods/token_add.rs`

**Preview:**
```Javascript
ethereum.request({
  "method": "wallet_updateEthereumChain",
  "params": [
    {
      "chainId": "0xa",
      "chainName": "Optimism",
      "rpcUrls": [
        "https://mainnet.optimism.io"
      ],
      "nativeCurrency": {
        "name": "Eth",
        "symbol": "ETH",
        "decimals": 18
      },
      "blockExplorerUrls": [
        "https://optimistic.etherscan.io"
      ]
    }
  ]
});
```
![image](https://github.com/user-attachments/assets/dd847bfe-5b1c-4a79-ad12-2f365eecc3b6)
![image](https://github.com/user-attachments/assets/45f927b8-9d21-40c8-9802-58defc693d63)
