### PR TITLE
Fix title bar in MacOS

### DIFF
--- a/bin/src/utils.rs
+++ b/bin/src/utils.rs
@@ -18,14 +18,12 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
         let builder = WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App(url.into()))
             .fullscreen(false)
             .resizable(true)
-            .decorations(false)
+            .decorations(true)
             .inner_size(600.0, 800.0)
             .on_menu_event(menu::event_handler);
 
         #[cfg(target_os = "macos")]
-        let builder = builder
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true);
+        let builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
 
         builder.build().unwrap();
     }


### PR DESCRIPTION
Why:
* In MacOS, the window was not draggable

How:
* Setting the title style to `Transparent` and enabling `decorations`