### PR TITLE
Fixing data-tauri-drag-region

### DIFF
--- a/bin/src/dialogs.rs
+++ b/bin/src/dialogs.rs
@@ -10,9 +10,7 @@ pub(crate) fn open(handle: &AppHandle, params: ui_events::DialogOpen) {
             .decorations(false);
 
     #[cfg(target_os = "macos")]
-    let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
-        .decorations(true);
+    let builder = builder.title_bar_style(tauri::TitleBarStyle::Overlay);
 
     let window = builder.build().unwrap();
 

--- a/bin/src/dialogs.rs
+++ b/bin/src/dialogs.rs
@@ -11,7 +11,7 @@ pub(crate) fn open(handle: &AppHandle, params: ui_events::DialogOpen) {
 
     #[cfg(target_os = "macos")]
     let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Transparent)
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
         .decorations(true);
 
     let window = builder.build().unwrap();

--- a/bin/src/utils.rs
+++ b/bin/src/utils.rs
@@ -23,9 +23,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
             .on_menu_event(menu::event_handler);
 
         #[cfg(target_os = "macos")]
-        let builder = builder
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .decorations(true);
+        let builder = builder.title_bar_style(tauri::TitleBarStyle::Overlay);
 
         builder.build().unwrap();
     }

--- a/bin/src/utils.rs
+++ b/bin/src/utils.rs
@@ -24,7 +24,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
 
         #[cfg(target_os = "macos")]
         let builder = builder
-            .title_bar_style(tauri::TitleBarStyle::Transparent)
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
             .decorations(true);
 
         builder.build().unwrap();

--- a/gui/src/components/AppNavbar.tsx
+++ b/gui/src/components/AppNavbar.tsx
@@ -12,7 +12,7 @@ export function AppNavbar() {
   return (
     <header
       data-tauri-drag-region="true"
-      className="sticky top-0 z-10 w-full flex-h-10 items-center bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      className="sticky top-0 z-10 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 h-10 flex items-center"
     >
       <Button
         className={clsx(!isMobile && "hidden")}

--- a/gui/src/components/AppNavbar.tsx
+++ b/gui/src/components/AppNavbar.tsx
@@ -12,18 +12,16 @@ export function AppNavbar() {
   return (
     <header
       data-tauri-drag-region="true"
-      className="sticky top-0 z-10 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      className="sticky top-0 z-10 w-full flex-h-10 items-center bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
     >
-      <div className="flex h-10 items-center">
-        <Button
-          className={clsx(!isMobile && "hidden")}
-          variant="ghost"
-          onClick={() => sidebar.toggleSidebar()}
-        >
-          <HamburgerMenuIcon />
-        </Button>
-        <Breadcrumbs />
-      </div>
+      <Button
+        className={clsx(!isMobile && "hidden")}
+        variant="ghost"
+        onClick={() => sidebar.toggleSidebar()}
+      >
+        <HamburgerMenuIcon />
+      </Button>
+      <Breadcrumbs />
     </header>
   );
 }

--- a/gui/src/components/AppNavbar.tsx
+++ b/gui/src/components/AppNavbar.tsx
@@ -12,7 +12,7 @@ export function AppNavbar() {
   return (
     <header
       data-tauri-drag-region="true"
-      className="sticky top-0 z-10 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 h-10 flex items-center"
+      className="sticky top-0 z-10 flex h-10 w-full items-center bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
     >
       <Button
         className={clsx(!isMobile && "hidden")}

--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -45,7 +45,10 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon">
-      <SidebarHeader className="flex items-center">
+      <SidebarHeader
+        className="flex items-center"
+        data-tauri-drag-region="true"
+      >
         <EthuiLogo
           size={48}
           bg="bg-transparent"
@@ -64,7 +67,7 @@ export function AppSidebar() {
                       href={item.url}
                       className={cn(
                         item.url === location.pathname &&
-                          "bg-primary text-accent hover:bg-primary hover:text-accent",
+                        "bg-primary text-accent hover:bg-primary hover:text-accent",
                       )}
                     >
                       {item.icon}
@@ -93,7 +96,7 @@ export function AppSidebar() {
                               href={item.url}
                               className={cn(
                                 item.url === location.pathname &&
-                                  "bg-primary text-accent hover:bg-primary hover:text-accent",
+                                "bg-primary text-accent hover:bg-primary hover:text-accent",
                               )}
                             >
                               {item.title}

--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -67,7 +67,7 @@ export function AppSidebar() {
                       href={item.url}
                       className={cn(
                         item.url === location.pathname &&
-                        "bg-primary text-accent hover:bg-primary hover:text-accent",
+                          "bg-primary text-accent hover:bg-primary hover:text-accent",
                       )}
                     >
                       {item.icon}
@@ -96,7 +96,7 @@ export function AppSidebar() {
                               href={item.url}
                               className={cn(
                                 item.url === location.pathname &&
-                                "bg-primary text-accent hover:bg-primary hover:text-accent",
+                                  "bg-primary text-accent hover:bg-primary hover:text-accent",
                               )}
                             >
                               {item.title}

--- a/gui/src/routes/dialog/_l.tsx
+++ b/gui/src/routes/dialog/_l.tsx
@@ -1,18 +1,33 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatedOutlet } from "#/components/AnimatedOutlet";
 import { useTheme } from "#/store/useTheme";
+import { EthuiLogo } from "@ethui/ui/components/ethui-logo";
 
 export const Route = createFileRoute("/dialog/_l")({
   component: DialogLayout,
 });
+
+const isDev = import.meta.env.MODE === "development";
 
 function DialogLayout() {
   // necessary to correctly apply dark mode
   useTheme();
 
   return (
-    <main className="flex h-screen w-screen flex-col overflow-hidden p-2">
-      <AnimatedOutlet />
-    </main>
+    // TODO: merge this header with the one from each dialog's layout, to save vertical space
+    // ideally the logo should just be in the left corner, before whatever each other dialog shows
+    <>
+      <header className="flex justify-center" data-tauri-drag-region>
+        <EthuiLogo
+          size={40}
+          bg="bg-transparent"
+          fg={isDev ? "fill-dev" : "fill-sidebar-foreground"}
+        />
+        &nbsp;
+      </header>
+      <main className="flex h-screen w-screen flex-col overflow-hidden p-2">
+        <AnimatedOutlet />
+      </main>
+    </>
   );
 }

--- a/gui/src/routes/dialog/_l.tsx
+++ b/gui/src/routes/dialog/_l.tsx
@@ -1,7 +1,7 @@
+import { EthuiLogo } from "@ethui/ui/components/ethui-logo";
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatedOutlet } from "#/components/AnimatedOutlet";
 import { useTheme } from "#/store/useTheme";
-import { EthuiLogo } from "@ethui/ui/components/ethui-logo";
 
 export const Route = createFileRoute("/dialog/_l")({
   component: DialogLayout,


### PR DESCRIPTION
Windows are now properly draggable, eliminating the need for the native overlay

Also added a small header with a logo on all dialogs, as a quick way to get drag functionality there too

closes #839 