### PR TITLE
Change setup to build both dev extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gui:devtools": "yarn workspace @ethui/gui devtools",
     "storybook": "yarn workspace @ethui/ui storybook",
     "ext:dev": "yarn workspace @ethui/extension dev",
+    "ext:dev:all": "yarn ext:dev --target chrome-dev && yarn ext:dev --target firefox-dev",
     "ext:watch": "yarn workspace @ethui/extension watch \"$@\"",
     "ext:build": "yarn workspace @ethui/extension build \"$@\"",
     "lint": "yarn lint:biome && yarn lint:tsc && yarn workspace @ethui/gui run lint",
@@ -18,7 +19,7 @@
     "lint:tsc": "yarn workspaces foreach --all --parallel run tsc --noEmit",
     "fix": "yarn fix:biome",
     "fix:biome": "biome check --write .",
-    "setup": "yarn install && yarn ext:build",
+    "setup": "yarn install && yarn ext:dev:all",
     "test": "yarn workspaces foreach --all run test",
     "demo:dev": "yarn workspace @ethui/demo dev",
     "demo:eth-watch": "yarn workspace @ethui/demo eth-watch"


### PR DESCRIPTION
I believe it makes more sense for the setup command to build all the development extensions. This approach should simplify the process for anyone setting up the repository, as it would have for me.