### PR TITLE
Fixing wallet_switchEthereumChain -> wallet_addEthereumChain flow

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -172,7 +172,6 @@ async fn event_listener(handle: AppHandle) {
 /// Otherwise, the app's default config dir will be used.
 fn resource(app: &tauri::App, resource: &str, args: &Args) -> PathBuf {
     let dir = config_dir(app, args);
-    debug!("config dir: {:?}", dir);
     std::fs::create_dir_all(&dir).expect("could not create config dir");
     dir.join(resource)
 }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -47,7 +47,6 @@ impl Ctx {
     }
 
     pub async fn switch_chain(&mut self, new_chain_id: u32) -> Result<()> {
-        dbg!(&self, &self.chain_id().await);
         if self.chain_id().await == new_chain_id {
             return Ok(());
         }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -47,6 +47,7 @@ impl Ctx {
     }
 
     pub async fn switch_chain(&mut self, new_chain_id: u32) -> Result<()> {
+        dbg!(&self, &self.chain_id().await);
         if self.chain_id().await == new_chain_id {
             return Ok(());
         }

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -43,6 +43,11 @@ pub enum Error {
     #[error(transparent)]
     Connection(#[from] ethui_connections::Error),
 
+    #[error(
+        "Unrecongnized chainID {0}. Try adding the chain using wallet_addEthereumChain first."
+    )]
+    UnrecognizedChainId(u32),
+
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),
 
@@ -107,6 +112,8 @@ impl From<Error> for jsonrpc_core::Error {
             Error::ErcTypeInvalid(..) => ErrorCode::ServerError(-32002),
             Error::ErcWrongOwner => ErrorCode::ServerError(-32002),
             Error::ErcInvalid => ErrorCode::ServerError(-32002),
+            // https://github.com/MetaMask/metamask-mobile/blob/5fe6aceffcf4c80ed1f3530282640aebcd201935/app/core/RPCMethods/wallet_switchEthereumChain.js#L88C11-L88C15
+            Error::UnrecognizedChainId(_) => ErrorCode::ServerError(4902),
             _ => ErrorCode::InternalError,
         };
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,6 +10,7 @@ use ethui_types::GlobalState;
 use ethui_wallets::{WalletControl, Wallets};
 use jsonrpc_core::{MetaIoHandler, Params};
 use serde_json::json;
+use tracing::debug;
 
 pub use self::error::{Error, Result};
 
@@ -198,15 +199,22 @@ impl Handler {
 
     #[tracing::instrument()]
     async fn switch_chain(params: Params, mut ctx: Ctx) -> jsonrpc_core::Result<serde_json::Value> {
+        debug!("switch_chain");
         let params = params.parse::<Vec<HashMap<String, String>>>().unwrap();
         let chain_id_str = params[0].get("chainId").unwrap().clone();
         let new_chain_id = u32::from_str_radix(&chain_id_str[2..], 16).unwrap();
+        dbg!(new_chain_id);
 
-        Ok(ctx
+        Ok(dbg!(ctx
             .switch_chain(new_chain_id)
             .await
-            .map(|_| serde_json::Value::Null)
-            .map_err(Error::Connection)?)
+            .map(|_| serde_json::Value::Null))
+        .map_err(|e| match e {
+            ethui_connections::Error::InvalidChainId(chain_id) => {
+                Error::UnrecognizedChainId(chain_id)
+            }
+            _ => Error::Connection(e),
+        })?)
     }
 
     async fn send_transaction<T: Into<serde_json::Value>>(


### PR DESCRIPTION
When connecting Metamask and other wallets via Rainbowkit to an unkonwn network, the request flow usually looks like:
- `wallet_switchEthereumChain`, error returned, because chain not recongnized by wallet
- `wallet_addEthereumChain` used as a reply by Rainbowkit

ethui failed to trigger the 2nd step, resulting in users having to manually adding the network, and no proper feedback coming in from the website.

According to some obscure find in metamask's source code, the only difference was the error code being returned by the json-rpc. after attempting to return that same code, the flow started working

I couldn't find any EIP or other documentation about this specific error code, so not sure it's even suposed to be official behaviour