### PR TITLE
Allow impersonator wallets to send transactions in Anvil

### DIFF
--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -140,7 +140,7 @@ mod internal_msgs {
         RwLock::new(tx)
     });
 
-    async fn send<'a>(msg: InternalMsg) {
+    async fn send(msg: InternalMsg) {
         INTERNAL.read().await.send(msg).unwrap();
     }
 }
@@ -185,7 +185,7 @@ mod ui_msgs {
         RwLock::new(tx)
     });
 
-    async fn send<'a>(msg: UIMsg) {
+    async fn send(msg: UIMsg) {
         INTERNAL.read().await.send(msg).unwrap();
     }
 }

--- a/crates/rpc/src/methods/send_call.rs
+++ b/crates/rpc/src/methods/send_call.rs
@@ -19,7 +19,7 @@ pub struct SendCall {
     pub request: TransactionRequest,
 }
 
-impl<'a> SendCall {
+impl SendCall {
     pub fn build(ctx: &Ctx) -> SendCallBuilder<'_> {
         SendCallBuilder::new(ctx)
     }

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -5,7 +5,7 @@ use alloy::{
     primitives::{Bytes, U256},
     providers::{ext::AnvilApi, PendingTransactionBuilder, Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
-    transports::http::{reqwest, Client, Http},
+    transports::http::{Client, Http},
 };
 use ethui_connections::Ctx;
 use ethui_dialogs::{Dialog, DialogMsg};
@@ -139,12 +139,9 @@ impl SendTransaction {
 
     async fn send(&mut self) -> Result<PendingTransactionBuilder<Http<Client>, Ethereum>> {
         self.build_provider().await?;
-        Ok(self
-            .provider
-            .as_ref()
-            .unwrap()
-            .send_transaction(self.request.clone())
-            .await?)
+        let provider = self.provider.as_ref().unwrap();
+        let pending = provider.send_transaction(self.request.clone()).await?;
+        Ok(pending)
     }
 
     async fn build_provider(&mut self) -> Result<()> {
@@ -176,7 +173,7 @@ impl SendTransaction {
                     .with_recommended_fillers()
                     .on_http(url);
 
-                provider.anvil_impersonate_account(account).await.unwrap();
+                provider.anvil_impersonate_account(account).await?;
 
                 self.provider = Some(Box::new(provider));
             }

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -164,20 +164,18 @@ impl SendTransaction {
         let is_dev_network = self.network.is_dev() && self.network.chain_id == 31337;
 
         match wallet {
-            Wallet::Impersonator(ref wallet) => {
-                if is_dev_network {
-                    let account = wallet.get_address(&self.wallet_path).await?;
-                    let provider = ProviderBuilder::new()
-                        .with_recommended_fillers()
-                        .on_http(url);
+            Wallet::Impersonator(ref wallet) if is_dev_network => {
+                let account = wallet.get_address(&self.wallet_path).await?;
+                let provider = ProviderBuilder::new()
+                    .with_recommended_fillers()
+                    .on_http(url);
 
-                    // TODO: maybe we can find a way to only do this once for every account,
-                    // or only call anvil_autoImpersonate once for the whole network,
-                    // instead of making this request for every single transaction.
-                    // this is just a minor optimization, though
-                    provider.anvil_impersonate_account(account).await?;
-                    self.provider = Some(Box::new(provider));
-                }
+                // TODO: maybe we can find a way to only do this once for every account,
+                // or only call anvil_autoImpersonate once for the whole network,
+                // instead of making this request for every single transaction.
+                // this is just a minor optimization, though
+                provider.anvil_impersonate_account(account).await?;
+                self.provider = Some(Box::new(provider));
             }
             _ => {
                 let signer = wallet

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -172,7 +172,8 @@ impl SendTransaction {
                         .on_http(url);
 
                     // TODO: maybe we can find a way to only do this once for every account,
-                    // or only call anvil_autoImpersonate once for the whole network, instead of making this request for every single transaction.
+                    // or only call anvil_autoImpersonate once for the whole network,
+                    // instead of making this request for every single transaction.
                     // this is just a minor optimization, though
                     provider.anvil_impersonate_account(account).await?;
                     self.provider = Some(Box::new(provider));

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -161,19 +161,24 @@ impl SendTransaction {
             .parse()
             .map_err(|_| Error::CannotParseUrl(self.network.http_url.clone()))?;
 
-        if self.network.is_dev() && self.network.chain_id == 31337 {
-            if let Wallet::Impersonator(ref wallet) = wallet {
-                let account = wallet.get_address(&self.wallet_path).await?;
-                let provider = ProviderBuilder::new()
-                    .with_recommended_fillers()
-                    .on_http(url);
+        let is_dev_network = self.network.is_dev() && self.network.chain_id == 31337;
 
-                // TODO: maybe we can find a way to only do this once for every account,
-                // or only call anvil_autoImpersonate once for the whole network, instead of making this request for every single transaction.
-                // this is just a minor optimization, though
-                provider.anvil_impersonate_account(account).await?;
-                self.provider = Some(Box::new(provider));
-            } else {
+        match wallet {
+            Wallet::Impersonator(ref wallet) => {
+                if is_dev_network {
+                    let account = wallet.get_address(&self.wallet_path).await?;
+                    let provider = ProviderBuilder::new()
+                        .with_recommended_fillers()
+                        .on_http(url);
+
+                    // TODO: maybe we can find a way to only do this once for every account,
+                    // or only call anvil_autoImpersonate once for the whole network, instead of making this request for every single transaction.
+                    // this is just a minor optimization, though
+                    provider.anvil_impersonate_account(account).await?;
+                    self.provider = Some(Box::new(provider));
+                }
+            }
+            _ => {
                 let signer = wallet
                     .build_signer(self.network.chain_id, &self.wallet_path)
                     .await?;
@@ -183,15 +188,6 @@ impl SendTransaction {
                     .on_http(url);
                 self.provider = Some(Box::new(provider));
             }
-        } else {
-            let signer = wallet
-                .build_signer(self.network.chain_id, &self.wallet_path)
-                .await?;
-            let provider = ProviderBuilder::new()
-                .with_recommended_fillers()
-                .wallet(signer.to_wallet())
-                .on_http(url);
-            self.provider = Some(Box::new(provider));
         };
 
         Ok(())

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -163,7 +163,7 @@ impl SendTransaction {
 
         let is_dev_network = self.network.is_dev() && self.network.chain_id == 31337;
 
-        match wallet {
+        self.provider = match wallet {
             Wallet::Impersonator(ref wallet) if is_dev_network => {
                 let account = wallet.get_address(&self.wallet_path).await?;
                 let provider = ProviderBuilder::new()
@@ -175,7 +175,7 @@ impl SendTransaction {
                 // instead of making this request for every single transaction.
                 // this is just a minor optimization, though
                 provider.anvil_impersonate_account(account).await?;
-                self.provider = Some(Box::new(provider));
+                Some(Box::new(provider))
             }
             _ => {
                 let signer = wallet
@@ -185,7 +185,7 @@ impl SendTransaction {
                     .with_recommended_fillers()
                     .wallet(signer.to_wallet())
                     .on_http(url);
-                self.provider = Some(Box::new(provider));
+                Some(Box::new(provider))
             }
         };
 

--- a/crates/wallets/src/wallets/impersonator.rs
+++ b/crates/wallets/src/wallets/impersonator.rs
@@ -72,6 +72,10 @@ impl WalletControl for Impersonator {
         Ok(self.addresses[usize::from_str(path)?])
     }
 
+    fn is_dev(&self) -> bool {
+        true
+    }
+
     async fn build_signer(&self, _chain_id: u32, _path: &str) -> Result<Signer> {
         Err(crate::Error::WalletCantSign)
     }


### PR DESCRIPTION
Why:
* Using an Anvil chain and an impersonator wallet we should be able to
  submit transactions, by taking advantage of the
  `anvil_impersonate_account` function
* Issue #827

How:
* Checking if the network is a dev network in the `build_provider`
  function of the `send_transaction.rs` to build an appropriate
  `Provider`
* Refactoring the `provider` type from `InnerProvider` to `Box<dyn
  Provider<Http<Client>>>` so we can make use of different providers to
  send transactions
* Adding the `is_dev` function to the impersonator wallet implementation
