### PR TITLE
Show dialogs in front of other windows

### DIFF
--- a/bin/src/windows/mod.rs
+++ b/bin/src/windows/mod.rs
@@ -26,7 +26,11 @@ pub fn build_window(
         .decorations(true)
         .title_bar_style(tauri::TitleBarStyle::Overlay);
 
-    builder.build().unwrap()
+    let window = builder.build().unwrap();
+    window.show().unwrap();
+    window.set_focus().unwrap();
+
+    window
 }
 
 /// Focuses all exiting windows, opening main window in the process if it doesn't exist


### PR DESCRIPTION
Why:
* When trigerring a dialog open, the dialog window would not come into
  focus, appearing behind all other windows

How:
* Setting focus and show the new window every time we build a window
