### PR TITLE
Production build was using previous name

### DIFF
--- a/bin/tauri.conf.json
+++ b/bin/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "productName": "iron",
+  "productName": "ethui",
   "identifier": "dev.ethui",
   "build": {
     "beforeDevCommand": "yarn workspace @ethui/gui dev",


### PR DESCRIPTION
Why:
* The title for the production build was still using the old name

How:
* Updating the `productName` attribute in `tauri.conf.json`
