### PR TITLE
Update mise production task

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,7 +6,7 @@ run = "yarn run app:dev"
 alias = "d"
 
 [tasks.prod]
-run = "yarn run tauri build"
+run = "yarn run app:build"
 env = { NODE_ENV = "production" }
 
 [tasks.fix]


### PR DESCRIPTION
Why:
* The `mise` production build task was using `yarn run tauri build`,
  causing Tauri to fail to build in MacOS as it doesn't have the
  `--target` option

How:
* Updating the `mise.toml` task to call the `app:build` script instead
