### PR TITLE
No longer fetch 'internal' alchemy transfers

### DIFF
--- a/crates/sync/alchemy/src/client.rs
+++ b/crates/sync/alchemy/src/client.rs
@@ -57,7 +57,7 @@ impl Client {
             "fromBlock": format!("0x{:x}", from_block),
             "toBlock": format!("0x{:x}", latest),
             "maxCount": "0x32",
-            "category": [ "external", "internal", "erc20", "erc721", "erc1155", "specialnft"],
+            "category": [ "external", "erc20", "erc721", "erc1155", "specialnft"],
         });
 
         let params_obj = params.as_object_mut().unwrap();


### PR DESCRIPTION
Closes #869 
only ethereum-mainnet/sepolia actually supports this. so instead of conditionally including this only for that case, might as well remove it alltogether. we'll have to revisit the idea of a custom indexer down the line if we want to enrich transaction history, but I don't see that as a priority