### PR TITLE
Update Form.Submit to allow skip dirty validation

### DIFF
--- a/gui/src/routes/onboarding/_l/alchemy.tsx
+++ b/gui/src/routes/onboarding/_l/alchemy.tsx
@@ -92,7 +92,7 @@ function OnboardingAlchemy() {
         </Button>
 
         <Form.Submit
-          skipDirty={true}
+          skipDirtyCheck={true}
           label={alchemyApiKey?.length > 0 ? "Next" : "Skip"}
         />
       </div>

--- a/gui/src/routes/onboarding/_l/alchemy.tsx
+++ b/gui/src/routes/onboarding/_l/alchemy.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
     .optional()
     .nullable()
     .superRefine(async (key, ctx) => {
-      if (key == "" || !key) return;
+      if (key === "" || !key) return;
       const valid = await invoke("settings_test_alchemy_api_key", { key });
       if (valid) return;
 

--- a/gui/src/routes/onboarding/_l/alchemy.tsx
+++ b/gui/src/routes/onboarding/_l/alchemy.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
     .optional()
     .nullable()
     .superRefine(async (key, ctx) => {
-      if (!key) return;
+      if (key == "" || !key) return;
       const valid = await invoke("settings_test_alchemy_api_key", { key });
       if (valid) return;
 
@@ -32,7 +32,11 @@ export const Route = createFileRoute("/onboarding/_l/alchemy")({
 
 function OnboardingAlchemy() {
   const router = useRouter();
-  const form = useForm({ mode: "onChange", resolver: zodResolver(schema) });
+  const form = useForm({
+    mode: "onChange",
+    resolver: zodResolver(schema),
+    defaultValues: { alchemyApiKey: "" },
+  });
 
   const alchemyApiKey = useWatch({
     control: form.control,
@@ -88,7 +92,7 @@ function OnboardingAlchemy() {
         </Button>
 
         <Form.Submit
-          useDirtyAlt={false}
+          skipDirty={true}
           label={alchemyApiKey?.length > 0 ? "Next" : "Skip"}
         />
       </div>

--- a/gui/src/routes/onboarding/_l/alchemy.tsx
+++ b/gui/src/routes/onboarding/_l/alchemy.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
     .optional()
     .nullable()
     .superRefine(async (key, ctx) => {
-      if (key === "" || !key) return;
+      if (!key) return;
       const valid = await invoke("settings_test_alchemy_api_key", { key });
       if (valid) return;
 

--- a/packages/ui/components/form.tsx
+++ b/packages/ui/components/form.tsx
@@ -214,30 +214,26 @@ Form.Checkbox = Checkbox;
 
 interface SubmitProps extends ButtonProps {
   label: React.ReactNode;
-  useDirtyAlt?: boolean;
+  skipDirty?: boolean;
   isSubmitting?: boolean;
 }
 
 function Submit({
+  skipDirty = false,
   label,
-  // this arg was kept here and defaulted to true for backwards compatibility,
-  // need to double check if the issue linked above is still required (for cases where array fields are present)
-  useDirtyAlt = true,
   isSubmitting: isSubmittingOverride = false,
   ...props
 }: SubmitProps) {
   const {
     formState: { isValid, isDirty, isSubmitting },
   } = useFormContext();
-  // https://github.com/react-hook-form/react-hook-form/issues/3213
-  //const isDirtyAlt = useDirtyAlt && !!Object.keys(dirtyFields).length;
+
+  const disabled = skipDirty
+    ? !isValid || isSubmitting
+    : !isDirty || !isValid || isSubmitting;
 
   return (
-    <Button
-      type="submit"
-      disabled={!isDirty || !isValid || isSubmitting}
-      {...props}
-    >
+    <Button type="submit" disabled={disabled} {...props}>
       {isSubmitting || isSubmittingOverride ? (
         <LoaderCircle className="animate-spin" />
       ) : (
@@ -281,7 +277,6 @@ function SelectInput<
       control={control}
       name={name}
       render={({ field }) => {
-        console.log(field.value);
         return (
           <FormItem className="flex items-baseline gap-2">
             <FormLabel className="shrink-0">{label}</FormLabel>

--- a/packages/ui/components/form.tsx
+++ b/packages/ui/components/form.tsx
@@ -214,12 +214,12 @@ Form.Checkbox = Checkbox;
 
 interface SubmitProps extends ButtonProps {
   label: React.ReactNode;
-  skipDirty?: boolean;
+  skipDirtyCheck?: boolean;
   isSubmitting?: boolean;
 }
 
 function Submit({
-  skipDirty = false,
+  skipDirtyCheck = false,
   label,
   isSubmitting: isSubmittingOverride = false,
   ...props
@@ -228,7 +228,7 @@ function Submit({
     formState: { isValid, isDirty, isSubmitting },
   } = useFormContext();
 
-  const disabled = skipDirty
+  const disabled = skipDirtyCheck
     ? !isValid || isSubmitting
     : !isDirty || !isValid || isSubmitting;
 


### PR DESCRIPTION
Why:
* In order to solve #877, we need a way to skip the `isDirty` attribute
  for disabling the form submit button

How:
* Setting a default value of empty string for the `alchemyApiKey` value
  in the Alchemy onboarding
* Adding a new prop, `skipDirty`, to the `Form.Submit`
