### PR TITLE
Removes foundry-config dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,6 @@ dependencies = [
  "ethui-types",
  "ethui-wallets",
  "eyre",
- "foundry-config",
  "foundry-evm",
  "pretty_assertions",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,8 @@ coins-ledger = "0.12"
 rand = "0.8"
 rstest = "0.23"
 regex = "1.11"
+anyhow = { version = "1.0", default-features = false }
 
 # Foundry - December 10th 2024
-foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "nightly-aa69ed1e46dd61fbf9d73399396a4db4dd527431" }
 foundry-evm = { git = "https://github.com/foundry-rs/foundry", rev = "nightly-aa69ed1e46dd61fbf9d73399396a4db4dd527431" }
 foundry-block-explorers = "0.8"
-anyhow = { version = "1.0", default-features = false }

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -18,7 +18,6 @@ tauri.workspace = true
 tokio.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-foundry-config.workspace = true
 foundry-evm.workspace = true
 alloy.workspace = true
 

--- a/crates/simulator/src/evm.rs
+++ b/crates/simulator/src/evm.rs
@@ -16,7 +16,6 @@ pub struct Evm {
 
 impl Evm {
     pub async fn new(fork_url: String, fork_block_number: Option<u64>, gas_limit: u64) -> Self {
-        let foundry_config = foundry_config::Config::default();
         let evm_opts = EvmOpts {
             fork_url: Some(fork_url.clone()),
             fork_block_number,
@@ -24,7 +23,7 @@ impl Evm {
                 gas_limit: u64::MAX.into(),
                 ..Default::default()
             },
-            memory_limit: foundry_config.memory_limit,
+            memory_limit: 1 << 27, // taken from foundry-config
             ..Default::default()
         };
 


### PR DESCRIPTION
The dependency is still there indirectly, but this simplifies our cargo.toml