### PR TITLE
Skip ABI fetch from Etherscan if network is Anvil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "alloy",
  "alloy-chains",
  "ethui-broadcast",
+ "ethui-networks",
  "ethui-settings",
  "ethui-types",
  "foundry-block-explorers 0.8.0",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 ethui-types.workspace = true
+ethui-networks.workspace = true
 ethui-settings.workspace = true
 ethui-broadcast.workspace = true
 

--- a/crates/db/src/commands.rs
+++ b/crates/db/src/commands.rs
@@ -1,13 +1,14 @@
 use alloy::json_abi::JsonAbi;
+use ethui_networks::Networks;
 use ethui_types::{
-    events::Tx, transactions::PaginatedTx, Address, Contract, Erc721TokenData, TokenBalance,
-    TokenMetadata, UINotify, B256, U256,
+    events::Tx, transactions::PaginatedTx, Address, Contract, Erc721TokenData, GlobalState,
+    TokenBalance, TokenMetadata, UINotify, B256, U256,
 };
 
 use super::{Paginated, Pagination, Result};
 use crate::{
     utils::{fetch_etherscan_abi, fetch_etherscan_contract_name},
-    Db,
+    Db, Error,
 };
 
 #[tauri::command]
@@ -93,16 +94,29 @@ pub async fn db_get_contract_abi(
 
 #[tauri::command]
 pub async fn db_insert_contract(
-    chain_id: u64,
+    chain_id: u32,
     address: Address,
     db: tauri::State<'_, Db>,
 ) -> Result<()> {
-    let name = fetch_etherscan_contract_name(chain_id.into(), address).await?;
-    let abi = fetch_etherscan_abi(chain_id.into(), address)
+    let network = Networks::read()
+        .await
+        .get_network(chain_id)
+        .ok_or(Error::InvalidNetwork(chain_id))?;
+
+    if network.is_dev().await {
+        db.insert_contract_with_abi(chain_id, address, None, None)
+            .await?;
+        ethui_broadcast::ui_notify(UINotify::ContractsUpdated).await;
+
+        return Ok(());
+    }
+
+    let name = fetch_etherscan_contract_name((chain_id as u64).into(), address).await?;
+    let abi = fetch_etherscan_abi((chain_id as u64).into(), address)
         .await?
         .map(|abi| serde_json::to_string(&abi).unwrap());
 
-    db.insert_contract_with_abi(chain_id as u32, address, abi, name)
+    db.insert_contract_with_abi(chain_id, address, abi, name)
         .await?;
 
     ethui_broadcast::ui_notify(UINotify::ContractsUpdated).await;

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -11,6 +11,12 @@ pub enum Error {
     #[error(transparent)]
     Etherscan(#[from] EtherscanError),
 
+    #[error("Invalid Network {0}")]
+    InvalidNetwork(u32),
+
+    #[error(transparent)]
+    Network(#[from] ethui_networks::Error),
+
     #[error("Invalid chain")]
     InvalidChain,
 

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -59,7 +59,7 @@ impl SendTransaction {
                 .get(&self.wallet_name)
                 .ok_or_else(|| Error::WalletNameNotFound(self.wallet_name.clone()))?;
 
-            self.network.is_dev() && wallet.is_dev() && Settings::read().await.fast_mode()
+            self.network.is_dev().await && wallet.is_dev() && Settings::read().await.fast_mode()
         };
 
         // skip the dialog if both network & wallet allow for it, and if fast_mode is enabled
@@ -161,7 +161,7 @@ impl SendTransaction {
             .parse()
             .map_err(|_| Error::CannotParseUrl(self.network.http_url.clone()))?;
 
-        let is_dev_network = self.network.is_dev() && self.network.chain_id == 31337;
+        let is_dev_network = self.network.is_dev().await && self.network.chain_id == 31337;
 
         self.provider = match wallet {
             Wallet::Impersonator(ref wallet) if is_dev_network => {

--- a/crates/rpc/src/methods/sign_message.rs
+++ b/crates/rpc/src/methods/sign_message.rs
@@ -29,8 +29,11 @@ impl<'a> SignMessage<'a> {
     }
 
     pub async fn finish(&mut self) -> Result<PrimitiveSignature> {
-        let skip =
-            { self.network.is_dev() && self.wallet.is_dev() && Settings::read().await.fast_mode() };
+        let skip = {
+            self.network.is_dev().await
+                && self.wallet.is_dev()
+                && Settings::read().await.fast_mode()
+        };
 
         if !skip {
             self.spawn_dialog().await?;

--- a/crates/sync/src/commands.rs
+++ b/crates/sync/src/commands.rs
@@ -21,7 +21,7 @@ pub async fn sync_get_native_balance(
         .ok_or(Error::InvalidNetwork(chain_id))?;
 
     // TODO: check with networks if this is anvil or not
-    if network.is_dev() {
+    if network.is_dev().await {
         Ok(ethui_sync_anvil::get_native_balance(network.http_url, address).await?)
     } else {
         Ok(db.get_native_balance(chain_id, address).await)

--- a/gui/src/store/useContracts.ts
+++ b/gui/src/store/useContracts.ts
@@ -45,7 +45,8 @@ const store: StateCreator<Store> = (set, get) => ({
 
   add: async (chainId: number, address: Address) => {
     try {
-      await invoke("db_insert_contract", { chainId: chainId, address });
+      // TODO check hex
+      await invoke("db_insert_contract", { chainId: Number(chainId), address });
     } catch (err: any) {
       toast({
         title: "Error",


### PR DESCRIPTION
Why:
* For every non-Anvil chain, there's a request to Etherscan to fetch the
  contract name and ABI. This makes it impossible to add a deployed
  contract to a non-local Anvil chain

How:
* Checking if the network is an instance of Anvil and skipping the
  calls to etherscan to fetch contract name and ABI
