### PR TITLE
Add `db_insert_contract_with_etherscan` command

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -37,6 +37,7 @@ impl EthUIApp {
                 ethui_networks::commands::networks_remove,
                 ethui_db::commands::db_get_contracts,
                 ethui_db::commands::db_insert_contract,
+                ethui_db::commands::db_insert_contract_with_etherscan,
                 ethui_db::commands::db_get_transactions,
                 ethui_db::commands::db_get_transaction_by_hash,
                 ethui_db::commands::db_get_contract_abi,

--- a/crates/db/src/commands.rs
+++ b/crates/db/src/commands.rs
@@ -92,7 +92,7 @@ pub async fn db_get_contract_abi(
 }
 
 #[tauri::command]
-pub async fn db_insert_contract(
+pub async fn db_insert_contract_with_etherscan(
     chain_id: u64,
     address: Address,
     db: tauri::State<'_, Db>,
@@ -103,6 +103,20 @@ pub async fn db_insert_contract(
         .map(|abi| serde_json::to_string(&abi).unwrap());
 
     db.insert_contract_with_abi(chain_id as u32, address, abi, name)
+        .await?;
+
+    ethui_broadcast::ui_notify(UINotify::ContractsUpdated).await;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn db_insert_contract(
+    chain_id: u64,
+    address: Address,
+    db: tauri::State<'_, Db>,
+) -> Result<()> {
+    db.insert_contract_with_abi(chain_id as u32, address, None, None)
         .await?;
 
     ethui_broadcast::ui_notify(UINotify::ContractsUpdated).await;

--- a/gui/src/store/useContracts.ts
+++ b/gui/src/store/useContracts.ts
@@ -45,7 +45,7 @@ const store: StateCreator<Store> = (set, get) => ({
 
   add: async (chainId: number, address: Address) => {
     try {
-      await invoke("db_insert_contract", { chainId, address });
+      await invoke("db_insert_contract_with_etherscan", { chainId, address });
     } catch (err: any) {
       toast({
         title: "Error",


### PR DESCRIPTION
Why:
* The `db_insert_contract` is making a call to Etherscan to fetch the
  contract name and ABI and this causes the insertion of a manual
  contract to fail if the contract is on a non-local Anvil node

How:
* Adding a `db_insert_contract_with_etherscan` to keep previous
  behaviour and updating all the calls to use the new name
* Adding a `db_insert_contract` that inserts a contract without making
  the call to Etherscan
