### PR TITLE
Cleanup warning about no alchemy key

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -4,7 +4,6 @@ use ethui_args::Args;
 use ethui_broadcast::UIMsg;
 use ethui_types::GlobalState as _;
 use tauri::{AppHandle, Builder, Emitter as _, Manager as _};
-use tracing::debug;
 
 use crate::{commands, error::AppResult, menu, system_tray, windows};
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,7 +10,6 @@ use ethui_types::GlobalState;
 use ethui_wallets::{WalletControl, Wallets};
 use jsonrpc_core::{MetaIoHandler, Params};
 use serde_json::json;
-use tracing::debug;
 
 pub use self::error::{Error, Result};
 

--- a/crates/sync/alchemy/src/utils.rs
+++ b/crates/sync/alchemy/src/utils.rs
@@ -5,7 +5,12 @@ use crate::{Alchemy, Error, Result};
 pub async fn get_current_api_key() -> Result<Option<String>> {
     let settings = ethui_settings::Settings::read().await;
 
-    Ok(settings.inner.alchemy_api_key.clone())
+    Ok(settings
+        .inner
+        .alchemy_api_key
+        .as_ref()
+        .cloned()
+        .filter(|s| !s.is_empty()))
 }
 
 pub async fn get_alchemy(chain_id: u32) -> Result<Alchemy> {

--- a/crates/sync/src/error.rs
+++ b/crates/sync/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
 
     #[error("No API Key")]
     NoApiKey,
+
+    #[error("Alchemy Error {0}")]
+    Alchemy(#[from] ethui_sync_alchemy::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -195,7 +195,6 @@ async fn get_alchemy(chain_id: u32) -> Result<ethui_sync_alchemy::Alchemy> {
         Ok(Some(api_key)) => api_key,
         _ => return Err(Error::NoApiKey),
     };
-    dbg!(&api_key);
     let alchemy = ethui_sync_alchemy::Alchemy::new(&api_key, ethui_db::get(), chain_id).unwrap();
 
     Ok(alchemy)

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -177,9 +177,8 @@ async fn unit_worker(
 ) -> Result<()> {
     loop {
         if ethui_sync_alchemy::supports_network(chain_id) {
-            let alchemy = get_alchemy(chain_id).await?;
-            if let Err(e) = alchemy.fetch_updates(addr).await {
-                warn!("Alchemy error: {:?}", e);
+            if let Ok(alchemy) = get_alchemy(chain_id).await {
+                alchemy.fetch_updates(addr).await?;
             };
         }
 
@@ -196,6 +195,7 @@ async fn get_alchemy(chain_id: u32) -> Result<ethui_sync_alchemy::Alchemy> {
         Ok(Some(api_key)) => api_key,
         _ => return Err(Error::NoApiKey),
     };
+    dbg!(&api_key);
     let alchemy = ethui_sync_alchemy::Alchemy::new(&api_key, ethui_db::get(), chain_id).unwrap();
 
     Ok(alchemy)


### PR DESCRIPTION
The alchemy API key would sometimes be an empty string rather than `None`, which would cause an error deep in the alchemy sync logic