### PR TITLE
Add proxy-detect crate as dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,14 +101,12 @@ dependencies = [
  "alloy-contract 0.11.0",
  "alloy-core",
  "alloy-eips 0.11.0",
- "alloy-genesis 0.11.0",
  "alloy-json-rpc 0.11.0",
  "alloy-network 0.11.0",
  "alloy-provider 0.11.0",
  "alloy-pubsub 0.11.0",
  "alloy-rpc-client 0.11.0",
  "alloy-rpc-types 0.11.0",
- "alloy-serde 0.11.0",
  "alloy-signer 0.11.0",
  "alloy-signer-aws",
  "alloy-signer-gcp",
@@ -244,7 +242,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-sol-types",
 ]
 
@@ -367,19 +364,6 @@ checksum = "aeec8e6eab6e52b7c9f918748c9b811e87dbef7312a2e3a2ca1729a92966a6af"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.7.3",
- "alloy-trie",
- "serde",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acaec0cc4c1489d61d6f33d0c3dd522c750025f4b5c8f59cd546221e4df660e5"
-dependencies = [
- "alloy-eips 0.11.0",
- "alloy-primitives",
- "alloy-serde 0.11.0",
  "alloy-trie",
  "serde",
 ]
@@ -2395,7 +2379,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
  "objc",
 ]
@@ -2623,7 +2607,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2636,7 +2620,7 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -3565,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "ethui-proxy-detect"
 version = "0.1.0"
-source = "git+https://github.com/ethui/proxy-detect?rev=c2ca98f#c2ca98faa897a8eefb5797c610eafdc1d7514d79"
+source = "git+https://github.com/ethui/proxy-detect?rev=d082648#d082648f329d51b79c76004ea4266c78ac69ecc5"
 dependencies = [
  "alloy",
  "thiserror 2.0.11",
@@ -3926,21 +3910,12 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -3953,12 +3928,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -4036,7 +4005,7 @@ source = "git+https://github.com/foundry-rs/foundry?rev=nightly-aa69ed1e46dd61fb
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
- "alloy-genesis 0.7.3",
+ "alloy-genesis",
  "alloy-json-abi",
  "alloy-network 0.7.3",
  "alloy-primitives",
@@ -4345,7 +4314,7 @@ source = "git+https://github.com/foundry-rs/foundry?rev=nightly-aa69ed1e46dd61fb
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
- "alloy-genesis 0.7.3",
+ "alloy-genesis",
  "alloy-json-abi",
  "alloy-network 0.7.3",
  "alloy-primitives",
@@ -5369,22 +5338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.5.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6384,23 +6337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6659,9 +6595,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
- "alloy-rlp",
  "const-hex",
- "proptest",
  "serde",
  "smallvec",
 ]
@@ -6926,48 +6860,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.105"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -8018,14 +7914,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.1",
  "hyper-rustls 0.27.3",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -8039,7 +7933,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-socks",
  "tokio-util",
@@ -9039,7 +8932,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics 0.24.0",
- "foreign-types 0.5.0",
+ "foreign-types",
  "js-sys",
  "log",
  "objc2",
@@ -10203,16 +10096,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,12 +101,14 @@ dependencies = [
  "alloy-contract 0.11.0",
  "alloy-core",
  "alloy-eips 0.11.0",
+ "alloy-genesis 0.11.0",
  "alloy-json-rpc 0.11.0",
  "alloy-network 0.11.0",
  "alloy-provider 0.11.0",
  "alloy-pubsub 0.11.0",
  "alloy-rpc-client 0.11.0",
  "alloy-rpc-types 0.11.0",
+ "alloy-serde 0.11.0",
  "alloy-signer 0.11.0",
  "alloy-signer-aws",
  "alloy-signer-gcp",
@@ -242,6 +244,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-sol-types",
 ]
 
@@ -364,6 +367,19 @@ checksum = "aeec8e6eab6e52b7c9f918748c9b811e87dbef7312a2e3a2ca1729a92966a6af"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.7.3",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaec0cc4c1489d61d6f33d0c3dd522c750025f4b5c8f59cd546221e4df660e5"
+dependencies = [
+ "alloy-eips 0.11.0",
+ "alloy-primitives",
+ "alloy-serde 0.11.0",
  "alloy-trie",
  "serde",
 ]
@@ -2379,7 +2395,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -2607,7 +2623,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2620,7 +2636,7 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -3380,6 +3396,7 @@ dependencies = [
  "ethui-dialogs",
  "ethui-forge",
  "ethui-networks",
+ "ethui-proxy-detect",
  "ethui-rpc",
  "ethui-settings",
  "ethui-simulator",
@@ -3543,6 +3560,15 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "ethui-proxy-detect"
+version = "0.1.0"
+source = "git+https://github.com/ethui/proxy-detect#c2ca98faa897a8eefb5797c610eafdc1d7514d79"
+dependencies = [
+ "alloy",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3900,12 +3926,21 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -3918,6 +3953,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -3995,7 +4036,7 @@ source = "git+https://github.com/foundry-rs/foundry?rev=nightly-aa69ed1e46dd61fb
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
- "alloy-genesis",
+ "alloy-genesis 0.7.3",
  "alloy-json-abi",
  "alloy-network 0.7.3",
  "alloy-primitives",
@@ -4304,7 +4345,7 @@ source = "git+https://github.com/foundry-rs/foundry?rev=nightly-aa69ed1e46dd61fb
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-dyn-abi",
- "alloy-genesis",
+ "alloy-genesis 0.7.3",
  "alloy-json-abi",
  "alloy-network 0.7.3",
  "alloy-primitives",
@@ -5328,6 +5369,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6327,6 +6384,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6585,7 +6659,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
+ "alloy-rlp",
  "const-hex",
+ "proptest",
  "serde",
  "smallvec",
 ]
@@ -6850,10 +6926,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -7904,12 +8018,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.1",
  "hyper-rustls 0.27.3",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7923,6 +8039,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-socks",
  "tokio-util",
@@ -8922,7 +9039,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics 0.24.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -10086,6 +10203,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "ethui-proxy-detect"
 version = "0.1.0"
-source = "git+https://github.com/ethui/proxy-detect?rev=d082648#d082648f329d51b79c76004ea4266c78ac69ecc5"
+source = "git+https://github.com/ethui/proxy-detect?rev=f3ce623#f3ce6232de16967baa9829e0fbc75a55ec5c7a62"
 dependencies = [
  "alloy",
  "thiserror 2.0.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "ethui-proxy-detect"
 version = "0.1.0"
-source = "git+https://github.com/ethui/proxy-detect#c2ca98faa897a8eefb5797c610eafdc1d7514d79"
+source = "git+https://github.com/ethui/proxy-detect?rev=c2ca98f#c2ca98faa897a8eefb5797c610eafdc1d7514d79"
 dependencies = [
  "alloy",
  "thiserror 2.0.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ethui-tracing = { path = "crates/tracing" }
 ethui-exchange-rates = { path = "crates/exchange-rates" }
 ethui-args = { path = "crates/args" }
 ethui-token-list = { path = "crates/token-list" }
+ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", rev = "c2ca98f" }
 tokio = { version = "1.42", features = ["rt-multi-thread", "sync"] }
 thiserror = "1.0"
 sqlx = { version = "0.8", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ethui-tracing = { path = "crates/tracing" }
 ethui-exchange-rates = { path = "crates/exchange-rates" }
 ethui-args = { path = "crates/args" }
 ethui-token-list = { path = "crates/token-list" }
-ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", rev = "c2ca98f" }
+ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", rev = "d082648" }
 tokio = { version = "1.42", features = ["rt-multi-thread", "sync"] }
 thiserror = "1.0"
 sqlx = { version = "0.8", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,9 @@ ethui-sync-anvil = { path = "crates/sync/anvil" }
 ethui-sync-alchemy = { path = "crates/sync/alchemy" }
 ethui-broadcast = { path = "crates/broadcast" }
 ethui-tracing = { path = "crates/tracing" }
-ethui-exchange-rates = { path = "crates/exchange-rates" }
 ethui-args = { path = "crates/args" }
 ethui-token-list = { path = "crates/token-list" }
-ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", rev = "d082648" }
+ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", rev = "f3ce623" }
 tokio = { version = "1.42", features = ["rt-multi-thread", "sync"] }
 thiserror = "1.0"
 sqlx = { version = "0.8", default-features = false, features = [
@@ -101,7 +100,6 @@ clap = { version = "4.5", default-features = false, features = [
   "derive",
   "env",
 ] }
-coins-ledger = "0.12"
 rand = "0.8"
 rstest = "0.23"
 regex = "1.11"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -44,7 +44,7 @@ named-lock = "0.4"
 tauri-plugin-os = "2.2"
 tauri-plugin-clipboard-manager = "2.0"
 tauri-plugin-shell = "2"
-ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", version = "0.1.0" }
+ethui-proxy-detect.workspace = true
 
 [build-dependencies]
 tauri-build = { version = "2.0", default-features = false, features = [] }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -44,6 +44,7 @@ named-lock = "0.4"
 tauri-plugin-os = "2.2"
 tauri-plugin-clipboard-manager = "2.0"
 tauri-plugin-shell = "2"
+ethui-proxy-detect = { git = "https://github.com/ethui/proxy-detect", version = "0.1.0" }
 
 [build-dependencies]
 tauri-build = { version = "2.0", default-features = false, features = [] }

--- a/deny.toml
+++ b/deny.toml
@@ -77,5 +77,5 @@ github = ["ethui"]
 [sources]
 allow-git = [
   "https://github.com/foundry-rs/foundry",
-  "https://github.com/tauri-apps/fix-path-env",
+  "https://github.com/tauri-apps/fix-path-env-rs",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -73,3 +73,9 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [sources.allow-org]
 github = ["ethui"]
+
+[sources]
+allow-git = [
+  "https://github.com/foundry-rs/foundry",
+  "https://github.com/tauri-apps/fix-path-env",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -70,3 +70,6 @@ name = "ring"
 version = "*"
 expression = "OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[sources.allow-org]
+github = ["ethui"]


### PR DESCRIPTION
Why:
* So we can detect if a contract address is a proxy contract

How:
* Adding `ethui-proxy-detect` as a dependency
