### PR TITLE
Clear affinities whenever a chain is removed

### DIFF
--- a/crates/connections/src/store.rs
+++ b/crates/connections/src/store.rs
@@ -46,4 +46,11 @@ impl Store {
 
         Ok(())
     }
+
+    /// Whenever a chain is removed, we need to clear all affinities to that chain
+    /// otherwise, new connections from the same website will fail
+    pub(crate) fn on_chain_removed(&mut self, chain_id: u32) {
+        self.affinities
+            .retain(|_, affinity| *affinity != chain_id.into());
+    }
 }

--- a/crates/types/src/affinity.rs
+++ b/crates/types/src/affinity.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Affinity {
     #[default]


### PR DESCRIPTION
If we remove a chain, but a website still has affinity to it, getting back to that website and connecting wallet would previously crash