### PR TITLE
Add window toggle permission

### DIFF
--- a/bin/capabilities/main.json
+++ b/bin/capabilities/main.json
@@ -2,6 +2,7 @@
   "identifier": "capabilities",
   "windows": ["*"],
   "permissions": [
+    "core:window:allow-internal-toggle-maximize",
     "core:window:allow-start-dragging",
     "core:window:allow-close",
     "core:event:allow-listen",


### PR DESCRIPTION
Why:
* The lack of the option `core:window:allow-internal-toggle-maximize`
  prevents a double click to toggle fullscreen in MacOS

How:
* Adding `core:window:allow-internal-toggle-maximize` to the
  `permissions` list in `capabilities/main.json`
