### PR TITLE
Remove contracts and transactions when removing network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "sqlx",
  "tauri",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -18,6 +18,7 @@ alloy-chains.workspace = true
 foundry-block-explorers.workspace = true
 sqlx.workspace = true
 tauri.workspace = true
+tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/db/src/init.rs
+++ b/crates/db/src/init.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use ethui_broadcast::InternalMsg;
 use once_cell::sync::OnceCell;
 
 use crate::{Db, DbInner, Result};
@@ -9,9 +10,27 @@ static DB: OnceCell<Db> = OnceCell::new();
 pub async fn init(path: &PathBuf) -> Result<Db> {
     let db = Arc::new(DbInner::connect(path).await.unwrap());
     DB.set(db.clone()).unwrap();
+
+    tokio::spawn(async { receiver().await });
+
     Ok(db)
 }
 
 pub fn get() -> Db {
     DB.get().unwrap().clone()
+}
+
+async fn receiver() -> ! {
+    let mut rx = ethui_broadcast::subscribe_internal().await;
+
+    loop {
+        if let Ok(msg) = rx.recv().await {
+            use InternalMsg::*;
+
+            if let NetworkRemoved(chain_id) = msg {
+                let _ = get().remove_contracts(chain_id).await;
+                let _ = get().remove_transactions(chain_id).await;
+            }
+        }
+    }
 }

--- a/crates/db/src/queries/contracts.rs
+++ b/crates/db/src/queries/contracts.rs
@@ -128,4 +128,12 @@ impl DbInner {
             .map(|r| (r.chain_id as u32, Address::from_str(&r.address).unwrap()))
             .collect())
     }
+
+    pub async fn remove_contracts(&self, chain_id: u32) -> Result<()> {
+        sqlx::query!(r#"DELETE FROM contracts where chain_id = ?"#, chain_id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/crates/db/src/queries/transactions.rs
+++ b/crates/db/src/queries/transactions.rs
@@ -158,6 +158,14 @@ impl DbInner {
         Ok(Paginated::new(items, pagination, total_row.total as u32))
     }
 
+    pub async fn remove_transactions(&self, chain_id: u32) -> Result<()> {
+        sqlx::query!(r#"DELETE FROM transactions where chain_id = ?"#, chain_id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn get_call_count(&self, chain_id: u32, from: Address, to: Address) -> Result<u32> {
         let from = format!("0x{:x}", from);
         let to = format!("0x{:x}", to);


### PR DESCRIPTION
Why:
* Fixes #950

How:
* Adding two new functions to the `db` crate to remove contracts and
  transactions from a specific chain id
* Adding an internal event listener to `db` to listen for the
  `NetworkRemoved` event and call the remove contracts and transactions
  functions
