### PR TITLE
Restore color indicators for transaction status

### DIFF
--- a/gui/src/routes/home/_l/transactions.tsx
+++ b/gui/src/routes/home/_l/transactions.tsx
@@ -126,12 +126,16 @@ interface IconProps {
 }
 
 function Icon({ account, tx }: IconProps) {
+  const colorClass = tx.status === 0 
+    ? 'text-destructive dark:text-destructive'     // red for failed/reverted
+    : 'text-[#22c55e] dark:text-[#4ade80]';       // green for successful
+
   if (!tx.to) {
     return <ReceiptText size={15} />;
   } else if (tx.to.toLowerCase() === account.toLowerCase()) {
-    return <MoveDownLeft size={15} />;
+    return <MoveDownLeft size={15} className={colorClass} />;
   } else {
-    return <MoveUpRight size={15} />;
+    return <MoveUpRight size={15} className={colorClass} />;
   }
 }
 


### PR DESCRIPTION
Fixes #840

This PR restores status-based color indicators for transaction icons that was removed during the Tailwind CSS migration.

Changes:
- Added conditional color classes based on transaction status
- Failed/Reverted transactions (status = 0) display in red
- Successful transactions (status = 1) display in green
- Color applies to both incoming (arrow down-left) and outgoing (arrow up-right) icons
- Colors are properly configured for both light and dark modes
- Contract deployment icons remain uncolored

The implementation uses transaction status to determine colors:
- Success (status = 1): Green indicator
- Failed/Reverted (status = 0): Red indicator

This maintains consistency with the pre-Tailwind implementation where colors indicated transaction status rather than direction.

Fixes issue #840

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ethui/ethui/pull/966?shareId=8321dbf4-0e61-487b-9b0c-153feddccb1b).