### PR TITLE
Reseting network when adding/removing/changing it

### DIFF
--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -97,6 +97,7 @@ impl Networks {
         self.save()?;
         ethui_broadcast::network_added(network.chain_id).await;
         ethui_broadcast::ui_notify(UINotify::NetworksChanged).await;
+        network.reset_listener().await?;
 
         Ok(())
     }
@@ -113,6 +114,7 @@ impl Networks {
         self.save()?;
         ethui_broadcast::network_updated(network.chain_id).await;
         ethui_broadcast::ui_notify(UINotify::NetworksChanged).await;
+        network.reset_listener().await?;
         Ok(())
     }
 

--- a/crates/networks/src/network.rs
+++ b/crates/networks/src/network.rs
@@ -116,7 +116,7 @@ impl Network {
         //Provider::new(client)
     }
 
-    pub async fn reset_listener(&mut self) -> Result<()> {
+    pub async fn reset_listener(&self) -> Result<()> {
         if self.is_dev().await {
             let http = Url::parse(&self.http_url)?;
             let ws = Url::parse(&self.ws_url())?;


### PR DESCRIPTION
When adding a new network, the anvil listener wasn't immediately reset