### PR TITLE
Save and restore sync status for Anvil chains

### DIFF
--- a/crates/sync/anvil/src/tracker.rs
+++ b/crates/sync/anvil/src/tracker.rs
@@ -132,7 +132,6 @@ async fn watch(
             .await
             .unwrap_or(serde_json::Value::Null);
 
-        // max between fork number and from_block +1
         let fork_block = node_info["forkConfig"]["forkBlockNumber"]
             .as_u64()
             .unwrap_or(0);


### PR DESCRIPTION
Why:
* To fix #932

How:
* Keeping track for all anvil chains of the latest known block number
* Skipping the db reset logic when the anvil provider still knows the
  saved known block number
