### PR TITLE
Move Network to `ethui_types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -1,5 +1,5 @@
-use ethui_networks::{Network, Networks};
-use ethui_types::{Affinity, GlobalState};
+use ethui_networks::Networks;
+use ethui_types::{Affinity, GlobalState, Network};
 
 use crate::{
     permissions::{Permission, PermissionRequest, RequestedPermission},

--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,6 +1,6 @@
-use ethui_types::GlobalState;
+use ethui_types::{GlobalState, Network};
 
-use super::{network::Network, Networks, Result};
+use super::{Networks, Result};
 
 #[tauri::command]
 pub async fn networks_get_current() -> Result<Network> {

--- a/crates/networks/src/init.rs
+++ b/crates/networks/src/init.rs
@@ -7,12 +7,12 @@ use std::{
 
 use async_trait::async_trait;
 use ethui_broadcast::InternalMsg;
-use ethui_types::{GlobalState, UINotify};
+use ethui_types::{GlobalState, Network, UINotify};
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use super::{network::Network, Networks};
+use super::Networks;
 
 static NETWORKS: OnceCell<RwLock<Networks>> = OnceCell::new();
 

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod commands;
 mod error;
 mod init;
-mod network;
 
 use std::{
     collections::HashMap,
@@ -10,14 +9,11 @@ use std::{
 };
 
 use alloy::{network::Ethereum, providers::RootProvider};
-use ethui_types::{Affinity, UINotify};
+use ethui_types::{Affinity, Network, UINotify};
 pub use init::init;
 use serde::Serialize;
 
-pub use self::{
-    error::{Error, Result},
-    network::Network,
-};
+pub use self::error::{Error, Result};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Networks {

--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -1,6 +1,6 @@
 use ethui_dialogs::{Dialog, DialogMsg};
-use ethui_networks::{Network, Networks};
-use ethui_types::{GlobalState, U64};
+use ethui_networks::Networks;
+use ethui_types::{GlobalState, Network, U64};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use url::Url;
@@ -120,7 +120,6 @@ impl TryFrom<Params> for Network {
                 .map(|s| s.to_string()),
             currency: params.native_currency.symbol,
             decimals: params.native_currency.decimals as u32,
-            force_is_anvil: false,
         })
     }
 }

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -1,7 +1,7 @@
 use crate::{Error, Result};
 use ethui_dialogs::{Dialog, DialogMsg};
-use ethui_networks::{Network, Networks};
-use ethui_types::GlobalState;
+use ethui_networks::Networks;
+use ethui_types::{GlobalState, Network};
 use serde::Serialize;
 
 use super::chain_add::Params;

--- a/crates/rpc/src/methods/send_call.rs
+++ b/crates/rpc/src/methods/send_call.rs
@@ -7,7 +7,7 @@ use alloy::{
     rpc::types::TransactionRequest,
 };
 use ethui_connections::Ctx;
-use ethui_networks::Network;
+use ethui_types::Network;
 
 use crate::Result;
 

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -8,9 +8,8 @@ use alloy::{
 };
 use ethui_connections::Ctx;
 use ethui_dialogs::{Dialog, DialogMsg};
-use ethui_networks::Network;
 use ethui_settings::Settings;
-use ethui_types::{Address, GlobalState};
+use ethui_types::{Address, GlobalState, Network};
 use ethui_wallets::{WalletControl, WalletType, Wallets};
 
 use crate::{Error, Result};

--- a/crates/rpc/src/methods/sign_message.rs
+++ b/crates/rpc/src/methods/sign_message.rs
@@ -6,9 +6,8 @@ use alloy::{
     signers::Signer as _,
 };
 use ethui_dialogs::{Dialog, DialogMsg};
-use ethui_networks::Network;
 use ethui_settings::Settings;
-use ethui_types::GlobalState;
+use ethui_types::{GlobalState, Network};
 use ethui_wallets::{Signer, Wallet, WalletControl};
 use serde::Serialize;
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -14,3 +14,4 @@ sqlx.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 alloy.workspace = true
+url.workspace = true

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -2,6 +2,7 @@ mod affinity;
 mod contracts;
 pub mod events;
 mod global_state;
+mod network;
 mod tokens;
 pub mod transactions;
 pub mod ui_events;
@@ -10,6 +11,7 @@ pub use alloy::primitives::{address, Address, B256, U256, U64};
 pub use contracts::{Contract, ContractWithAbi};
 pub use events::Event;
 pub use global_state::GlobalState;
+pub use network::Network;
 pub use tokens::{
     Erc1155Token, Erc1155TokenData, Erc721Collection, Erc721Token, Erc721TokenData,
     Erc721TokenDetails, TokenBalance, TokenMetadata,

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -108,13 +108,7 @@ impl Network {
         //Provider::new(client)
     }
 
-    pub async fn reset_listener(&self) -> Result<()> {
-        if self.is_dev().await {
-            let http = Url::parse(&self.http_url)?;
-            let ws = Url::parse(&self.ws_url())?;
-            ethui_broadcast::reset_anvil_listener(self.chain_id, http, ws).await;
-        }
-
+    pub async fn reset_listener(&self) -> Result<(), RpcError<TransportErrorKind>> {
         Ok(())
     }
 }


### PR DESCRIPTION
Why:
* In order to prevent a cyclic dependency and so we can use the
  `Network` struct for sending as parameter in Network related events

How:
* Moving the `networks/src/network.rs` file to `types/src/network.rs`
* Updating references to point to the new location
* Removing `force_is_anvil` field as it is no longer used
