### PR TITLE
Update Network events

### DIFF
--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ethui_types::{ui_events, Address, Affinity, B256};
+use ethui_types::{ui_events, Address, Affinity, Network, B256};
 pub use internal_msgs::*;
 use once_cell::sync::Lazy;
 use tokio::sync::{broadcast, oneshot, Mutex, RwLock};
@@ -24,10 +24,10 @@ pub enum InternalMsg {
     AddressRemoved(Address),
     CurrentAddressChanged(Address),
 
-    NetworkAdded(u32),
-    NetworkUpdated(u32),
-    NetworkRemoved(u32),
-    CurrentNetworkChanged(u32),
+    NetworkAdded(Network),
+    NetworkUpdated(Network),
+    NetworkRemoved(Network),
+    CurrentNetworkChanged(Network),
 
     /// Request a full update of a TX. oneshot channel included to notify when job is done
     FetchFullTxSync(u32, B256, Arc<Mutex<Option<oneshot::Sender<()>>>>),
@@ -98,20 +98,20 @@ mod internal_msgs {
         send(CurrentAddressChanged(address)).await;
     }
 
-    pub async fn network_added(chain_id: u32) {
-        send(NetworkAdded(chain_id)).await;
+    pub async fn network_added(network: Network) {
+        send(NetworkAdded(network)).await;
     }
 
-    pub async fn network_updated(chain_id: u32) {
-        send(NetworkUpdated(chain_id)).await;
+    pub async fn network_updated(network: Network) {
+        send(NetworkUpdated(network)).await;
     }
 
-    pub async fn network_removed(chain_id: u32) {
-        send(NetworkRemoved(chain_id)).await;
+    pub async fn network_removed(network: Network) {
+        send(NetworkRemoved(network)).await;
     }
 
-    pub async fn current_network_changed(chain_id: u32) {
-        send(CurrentNetworkChanged(chain_id)).await;
+    pub async fn current_network_changed(network: Network) {
+        send(CurrentNetworkChanged(network)).await;
     }
 
     pub async fn forge_abi_found() {

--- a/crates/connections/src/init.rs
+++ b/crates/connections/src/init.rs
@@ -64,9 +64,9 @@ async fn receiver() -> ! {
         if let Ok(msg) = rx.recv().await {
             use InternalMsg::*;
 
-            if let NetworkRemoved(chain_id) = msg {
+            if let NetworkRemoved(network) = msg {
                 let mut store = Store::write().await;
-                store.on_chain_removed(chain_id);
+                store.on_chain_removed(network.chain_id);
             }
         }
     }

--- a/crates/db/src/init.rs
+++ b/crates/db/src/init.rs
@@ -27,11 +27,11 @@ async fn receiver() -> ! {
         if let Ok(msg) = rx.recv().await {
             use InternalMsg::*;
 
-            if let NetworkRemoved(chain_id) = msg {
+            if let NetworkRemoved(network) = msg {
                 let db = get();
 
-                let _ = db.remove_contracts(chain_id).await;
-                let _ = db.remove_transactions(chain_id).await;
+                let _ = db.remove_contracts(network.chain_id).await;
+                let _ = db.remove_transactions(network.chain_id).await;
             }
         }
     }

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -91,7 +91,7 @@ impl Networks {
 
         self.networks.insert(network.name.clone(), network.clone());
         self.save()?;
-        ethui_broadcast::network_added(network.chain_id).await;
+        ethui_broadcast::network_added(network.clone()).await;
         ethui_broadcast::ui_notify(UINotify::NetworksChanged).await;
         network.reset_listener().await?;
 
@@ -100,7 +100,8 @@ impl Networks {
 
     pub async fn update_network(&mut self, old_name: &str, network: Network) -> Result<()> {
         self.networks.remove(old_name);
-        self.networks.insert(network.name.clone(), network.clone());
+        self.networks
+            .insert(network.clone().name.clone(), network.clone());
 
         if self.current == old_name {
             self.current = network.name.clone();
@@ -108,7 +109,7 @@ impl Networks {
         }
 
         self.save()?;
-        ethui_broadcast::network_updated(network.chain_id).await;
+        ethui_broadcast::network_updated(network.clone()).await;
         ethui_broadcast::ui_notify(UINotify::NetworksChanged).await;
         network.reset_listener().await?;
         Ok(())
@@ -125,7 +126,7 @@ impl Networks {
                     self.on_network_changed().await?;
                 }
                 self.save()?;
-                ethui_broadcast::network_removed(network.chain_id).await;
+                ethui_broadcast::network_removed(network).await;
                 ethui_broadcast::ui_notify(UINotify::NetworksChanged).await;
             }
             None => {
@@ -144,8 +145,8 @@ impl Networks {
         self.notify_peers();
         ethui_broadcast::ui_notify(UINotify::CurrentNetworkChanged).await;
 
-        let chain_id = self.get_current().chain_id;
-        ethui_broadcast::current_network_changed(chain_id).await;
+        let network = self.get_current().clone();
+        ethui_broadcast::current_network_changed(network).await;
 
         Ok(())
     }
@@ -160,11 +161,11 @@ impl Networks {
 
     async fn broadcast_init(&self) {
         for network in self.networks.values() {
-            ethui_broadcast::network_added(network.chain_id).await;
+            ethui_broadcast::network_added(network.clone()).await;
         }
 
-        let chain_id = self.get_current().chain_id;
-        ethui_broadcast::current_network_changed(chain_id).await;
+        let network = self.get_current().clone();
+        ethui_broadcast::current_network_changed(network).await;
     }
 
     async fn reset_listeners(&mut self) {

--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -110,14 +110,12 @@ impl TryFrom<Params> for Network {
                 .iter()
                 .find(|s| s.scheme().starts_with("http"))
                 .cloned()
-                .expect("http url not found")
-                .to_string(),
+                .expect("http url not found"),
             ws_url: params
                 .rpc_urls
                 .iter()
                 .find(|s| s.scheme().starts_with("ws"))
-                .cloned()
-                .map(|s| s.to_string()),
+                .cloned(),
             currency: params.native_currency.symbol,
             decimals: params.native_currency.decimals as u32,
         })

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -154,8 +154,9 @@ impl SendTransaction {
         let url = self
             .network
             .http_url
+            .to_string()
             .parse()
-            .map_err(|_| Error::CannotParseUrl(self.network.http_url.clone()))?;
+            .map_err(|_| Error::CannotParseUrl(self.network.http_url.to_string().clone()))?;
 
         self.provider = if self.network.is_dev().await {
             // TODO: maybe we can find a way to only do this once for every account,

--- a/crates/simulator/src/commands.rs
+++ b/crates/simulator/src/commands.rs
@@ -12,7 +12,7 @@ use crate::{
 pub async fn simulator_run(chain_id: u32, request: Request) -> SimulationResult<Result> {
     let network = Networks::read().await.get_network(chain_id).unwrap();
 
-    let mut evm = Evm::new(network.http_url, None, request.gas_limit).await;
+    let mut evm = Evm::new(network.http_url.to_string(), None, request.gas_limit).await;
 
     evm.call(request).await
 }

--- a/crates/sync/src/commands.rs
+++ b/crates/sync/src/commands.rs
@@ -22,7 +22,7 @@ pub async fn sync_get_native_balance(
 
     // TODO: check with networks if this is anvil or not
     if network.is_dev().await {
-        Ok(ethui_sync_anvil::get_native_balance(network.http_url, address).await?)
+        Ok(ethui_sync_anvil::get_native_balance(network.http_url.to_string(), address).await?)
     } else {
         Ok(db.get_native_balance(chain_id, address).await)
     }

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -42,9 +42,9 @@ impl TryFrom<InternalMsg> for Msg {
             InternalMsg::AddressAdded(addr) => Msg::TrackAddress(addr),
             InternalMsg::AddressRemoved(addr) => Msg::UntrackAddress(addr),
             InternalMsg::CurrentAddressChanged(addr) => Msg::PollAddress(addr),
-            InternalMsg::NetworkAdded(chain_id) => Msg::TrackNetwork(chain_id),
-            InternalMsg::NetworkRemoved(chain_id) => Msg::UntrackNetwork(chain_id),
-            InternalMsg::CurrentNetworkChanged(chain_id) => Msg::PollNetwork(chain_id),
+            InternalMsg::NetworkAdded(network) => Msg::TrackNetwork(network.chain_id),
+            InternalMsg::NetworkRemoved(network) => Msg::UntrackNetwork(network.chain_id),
+            InternalMsg::CurrentNetworkChanged(network) => Msg::PollNetwork(network.chain_id),
             InternalMsg::FetchFullTxSync(chain_id, hash, oneshot) => {
                 Msg::FetchFullTxSync(chain_id, hash, oneshot)
             }


### PR DESCRIPTION
Why:
* The Network events were passing only the `chain_id`. We want to send
  the entire `Network` struct so we can access other fields

How:
* Updating the declaration for `NetworkAdded`, `NetworkRemoved`,
  `NetworkUpdated`, `CurrentNetworkChanged` to receive a `Network`
* Updating all the references to use the new type
