### PR TITLE
Fix PR lint action

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -39,7 +39,7 @@ jobs:
           done
 
           if [[ ! $MATCH_FOUND -eq 1 ]]; then
-            eco "No matching labels found. Must have one of: ${{ steps.current-labels.outputs.labels }}"
+            echo "No matching labels found. Must have one of: ${{ steps.current-labels.outputs.labels }}"
             exit 1
           fi
         env:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get release-drafter config
         id: current-labels
         run: |
-          echo "labels=$(yq -r '.categories[].labels | flatten[]' .github/release-drafter.yml | tr '\n' ',')" >> $GITHUB_OUTPUT
+          echo "labels=$(yq -r '[.categories[].labels, .exclude-labels] | flatten[]' .github/release-drafter.yml | tr '\n' ',')" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Check PR labels


### PR DESCRIPTION
Why:
* There's a typo in the command name for `echo`
* Include `exclude-labels` in the list of labels a PR needs to include
