### PR TITLE
Add internal_id field to Networks

### DIFF
--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,6 +1,5 @@
-use ethui_types::{GlobalState, Network};
-
 use super::{Networks, Result};
+use ethui_types::{GlobalState, Network, NewNetworkParams};
 
 #[tauri::command]
 pub async fn networks_get_current() -> Result<Network> {
@@ -26,7 +25,7 @@ pub async fn networks_set_current(network: String) -> Result<Network> {
 }
 
 #[tauri::command]
-pub async fn networks_add(network: Network) -> Result<()> {
+pub async fn networks_add(network: NewNetworkParams) -> Result<()> {
     let mut networks = Networks::write().await;
     networks.add_network(network).await?;
     Ok(())

--- a/crates/networks/src/migrations.rs
+++ b/crates/networks/src/migrations.rs
@@ -25,7 +25,7 @@ struct SerializedNetworksV0 {
 #[derive(Debug, Deserialize, Serialize)]
 struct SerializedNetworksV1 {
     current: String,
-    networks: HashMap<String, NetworkV1>,
+    networks: HashMap<String, NetworkV0>,
     version: ConstI64<1>,
 }
 
@@ -39,17 +39,6 @@ enum Versions {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct NetworkV0 {
-    pub name: String,
-    pub chain_id: u32,
-    pub explorer_url: Option<String>,
-    pub http_url: Url,
-    pub ws_url: Option<Url>,
-    pub currency: String,
-    pub decimals: u32,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct NetworkV1 {
     pub name: String,
     pub chain_id: u32,
     pub explorer_url: Option<String>,
@@ -87,7 +76,7 @@ fn run_migrations(networks: Versions) -> SerializedNetworks {
         Versions::V0(v0) => {
             let v1 = Versions::V1(SerializedNetworksV1 {
                 current: v0.current,
-                networks: migrate_networks_from_v0_to_v1(v0.networks),
+                networks: v0.networks,
                 version: ConstI64,
             });
 
@@ -102,30 +91,8 @@ fn run_migrations(networks: Versions) -> SerializedNetworks {
     }
 }
 
-fn migrate_networks_from_v0_to_v1(
-    networks: HashMap<String, NetworkV0>,
-) -> HashMap<String, NetworkV1> {
-    networks
-        .into_iter()
-        .map(|(name, network)| {
-            (
-                name,
-                NetworkV1 {
-                    name: network.name,
-                    chain_id: network.chain_id,
-                    explorer_url: network.explorer_url,
-                    http_url: network.http_url,
-                    ws_url: network.ws_url,
-                    currency: network.currency,
-                    decimals: network.decimals,
-                },
-            )
-        })
-        .collect::<HashMap<String, NetworkV1>>()
-}
-
 fn migrate_networks_from_v1_to_v2(
-    networks: HashMap<String, NetworkV1>,
+    networks: HashMap<String, NetworkV0>,
 ) -> HashMap<String, Network> {
     networks
         .into_iter()

--- a/crates/networks/src/migrations.rs
+++ b/crates/networks/src/migrations.rs
@@ -8,24 +8,55 @@ use std::{
     io::BufReader,
     path::{Path, PathBuf},
 };
+use url::Url;
 
 use crate::Result;
 use crate::{Networks, SerializedNetworks};
 
-pub type LatestVersion = ConstI64<1>;
+pub type LatestVersion = ConstI64<2>;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct SerializedNetworksV0 {
     current: String,
-    networks: HashMap<String, Network>,
+    networks: HashMap<String, NetworkV0>,
     version: ConstI64<0>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SerializedNetworksV1 {
+    current: String,
+    networks: HashMap<String, NetworkV1>,
+    version: ConstI64<1>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 enum Versions {
     V0(SerializedNetworksV0),
-    V1(SerializedNetworks),
+    V1(SerializedNetworksV1),
+    V2(SerializedNetworks),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NetworkV0 {
+    pub name: String,
+    pub chain_id: u32,
+    pub explorer_url: Option<String>,
+    pub http_url: Url,
+    pub ws_url: Option<Url>,
+    pub currency: String,
+    pub decimals: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NetworkV1 {
+    pub name: String,
+    pub chain_id: u32,
+    pub explorer_url: Option<String>,
+    pub http_url: Url,
+    pub ws_url: Option<Url>,
+    pub currency: String,
+    pub decimals: u32,
 }
 
 pub(crate) fn load_and_migrate(pathbuf: &PathBuf) -> Result<Networks> {
@@ -53,13 +84,68 @@ pub(crate) fn load_and_migrate(pathbuf: &PathBuf) -> Result<Networks> {
 
 fn run_migrations(networks: Versions) -> SerializedNetworks {
     match networks {
-        Versions::V0(v0) => SerializedNetworks {
-            current: v0.current,
-            networks: v0.networks,
+        Versions::V0(v0) => {
+            let v1 = Versions::V1(SerializedNetworksV1 {
+                current: v0.current,
+                networks: migrate_networks_from_v0_to_v1(v0.networks),
+                version: ConstI64,
+            });
+
+            run_migrations(v1)
+        }
+        Versions::V1(v1) => SerializedNetworks {
+            current: v1.current,
+            networks: migrate_networks_from_v1_to_v2(v1.networks),
             version: ConstI64,
         },
-        Versions::V1(latest) => latest,
+        Versions::V2(latest) => latest,
     }
+}
+
+fn migrate_networks_from_v0_to_v1(
+    networks: HashMap<String, NetworkV0>,
+) -> HashMap<String, NetworkV1> {
+    networks
+        .into_iter()
+        .map(|(name, network)| {
+            (
+                name,
+                NetworkV1 {
+                    name: network.name,
+                    chain_id: network.chain_id,
+                    explorer_url: network.explorer_url,
+                    http_url: network.http_url,
+                    ws_url: network.ws_url,
+                    currency: network.currency,
+                    decimals: network.decimals,
+                },
+            )
+        })
+        .collect::<HashMap<String, NetworkV1>>()
+}
+
+fn migrate_networks_from_v1_to_v2(
+    networks: HashMap<String, NetworkV1>,
+) -> HashMap<String, Network> {
+    networks
+        .into_iter()
+        .map(|(name, network)| {
+            (
+                name,
+                Network {
+                    // at the time of this migration no duplicate chain id were allowed
+                    deduplication_id: 0,
+                    name: network.name,
+                    chain_id: network.chain_id,
+                    explorer_url: network.explorer_url,
+                    http_url: network.http_url,
+                    ws_url: network.ws_url,
+                    currency: network.currency,
+                    decimals: network.decimals,
+                },
+            )
+        })
+        .collect::<HashMap<String, Network>>()
 }
 
 #[cfg(test)]
@@ -70,6 +156,8 @@ mod tests {
         io::{BufReader, Write},
     };
     use tempfile::NamedTempFile;
+
+    use crate::SerializedNetworks;
 
     use super::load_and_migrate;
 
@@ -99,16 +187,16 @@ mod tests {
             let reader = BufReader::new(file);
 
             let updated_networks: serde_json::Value = serde_json::from_reader(reader).unwrap();
-            assert_eq!(updated_networks["version"], 1);
+            assert_eq!(updated_networks["version"], 2);
         }
     }
 
     #[test]
-    fn it_returns_v1_from_v1() {
+    fn it_returns_v2_from_v2() {
         let mut tempfile = NamedTempFile::new().unwrap();
 
         let networks_v0 = json!({
-            "version": 1,
+            "version": 2,
             "current": "Anvil",
             "networks": {
                 "Mainnet": {
@@ -130,7 +218,7 @@ mod tests {
             let reader = BufReader::new(file);
 
             let updated_networks: serde_json::Value = serde_json::from_reader(reader).unwrap();
-            assert_eq!(updated_networks["version"], 1);
+            assert_eq!(updated_networks["version"], 2);
         }
     }
 
@@ -159,5 +247,38 @@ mod tests {
         let result = load_and_migrate(&tempfile.path().to_path_buf());
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn it_migrates_network_to_include_internal_id() {
+        let mut tempfile = NamedTempFile::new().unwrap();
+
+        let networks_v0 = json!({
+            "version": 1,
+            "current": "Anvil",
+            "networks": {
+                "Mainnet": {
+                    "name": "Mainnet",
+                    "chain_id": 1,
+                    "explorer_url": "https://etherscan.io/search?q=",
+                    "http_url": "https://eth.llamarpc.com/",
+                    "ws_url": null,
+                    "currency": "ETH",
+                    "decimals": 18
+                },
+            }
+        });
+
+        write!(tempfile, "{}", networks_v0).unwrap();
+
+        if let Ok(_networks) = load_and_migrate(&tempfile.path().to_path_buf()) {
+            let file = File::open(tempfile.path()).unwrap();
+            let reader = BufReader::new(file);
+
+            let updated_networks: SerializedNetworks = serde_json::from_reader(reader).unwrap();
+            let mainnet = updated_networks.networks.get("Mainnet").unwrap();
+
+            assert_eq!(mainnet.internal_id(), (mainnet.chain_id, 0));
+        }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -179,7 +179,8 @@ impl Handler {
     async fn add_chain(params: Params, _ctx: Ctx) -> jsonrpc_core::Result<serde_json::Value> {
         let method = methods::ChainAdd::build()
             .set_params(params.into())?
-            .build();
+            .build()
+            .await;
 
         method.run().await?;
 

--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -1,6 +1,6 @@
 use ethui_dialogs::{Dialog, DialogMsg};
 use ethui_networks::Networks;
-use ethui_types::{GlobalState, Network, U64};
+use ethui_types::{GlobalState, NewNetworkParams, U64};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use url::Url;
@@ -9,7 +9,7 @@ use crate::{Error, Result};
 
 #[derive(Debug)]
 pub struct ChainAdd {
-    network: Network,
+    network: NewNetworkParams,
 }
 
 impl ChainAdd {
@@ -50,6 +50,7 @@ impl ChainAdd {
 
     pub async fn on_accept(&self) -> Result<()> {
         let mut networks = Networks::write().await;
+
         networks.add_network(self.network.clone()).await?;
 
         Ok(())
@@ -59,19 +60,19 @@ impl ChainAdd {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Params {
-    chain_id: U64,
-    chain_name: String,
-    rpc_urls: Vec<Url>,
-    native_currency: Currency,
-    block_explorer_urls: Vec<Url>,
+    pub chain_id: U64,
+    pub chain_name: String,
+    pub rpc_urls: Vec<Url>,
+    pub native_currency: Currency,
+    pub block_explorer_urls: Vec<Url>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Currency {
-    name: String,
-    symbol: String,
-    decimals: u64,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u64,
 }
 
 #[derive(Debug, Default)]
@@ -91,14 +92,14 @@ impl ChainAddBuilder {
         Ok(self)
     }
 
-    pub fn build(self) -> ChainAdd {
+    pub async fn build(self) -> ChainAdd {
         ChainAdd {
             network: self.params.unwrap().try_into().unwrap(),
         }
     }
 }
 
-impl TryFrom<Params> for Network {
+impl TryFrom<Params> for NewNetworkParams {
     type Error = Error;
     fn try_from(params: Params) -> Result<Self> {
         Ok(Self {

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -1,7 +1,7 @@
 use crate::{Error, Result};
 use ethui_dialogs::{Dialog, DialogMsg};
 use ethui_networks::Networks;
-use ethui_types::{GlobalState, Network};
+use ethui_types::{GlobalState, Network, NewNetworkParams};
 use serde::Serialize;
 
 use super::chain_add::Params;
@@ -9,6 +9,7 @@ use super::chain_add::Params;
 #[derive(Debug)]
 pub struct ChainUpdate {
     network: Network,
+    new_network_params: Option<NewNetworkParams>,
 }
 
 impl ChainUpdate {
@@ -22,7 +23,10 @@ impl ChainUpdate {
         }
 
         if !self.already_exists().await {
-            let add_dialog = Dialog::new("chain-add", serde_json::to_value(&self.network).unwrap());
+            let add_dialog = Dialog::new(
+                "chain-add",
+                serde_json::to_value(&self.new_network_params).unwrap(),
+            );
             add_dialog.open().await?;
 
             while let Some(msg) = add_dialog.recv().await {
@@ -30,7 +34,9 @@ impl ChainUpdate {
                     DialogMsg::Data(msg) => {
                         if let Some("accept") = msg.as_str() {
                             let mut networks = Networks::write().await;
-                            networks.add_network(self.network.clone()).await?;
+                            networks
+                                .add_network(self.new_network_params.clone().unwrap())
+                                .await?;
                             break;
                         }
                     }
@@ -75,7 +81,7 @@ impl ChainUpdate {
 
     async fn already_exists(&self) -> bool {
         let networks = Networks::read().await;
-        networks.validate_chain_id(self.network.chain_id)
+        networks.get_network_by_name(&self.network.name).is_some()
     }
 }
 
@@ -104,8 +110,38 @@ impl ChainUpdateBuilder {
     }
 
     pub async fn build(self) -> ChainUpdate {
+        let networks = Networks::read().await;
+        let params = self.params.unwrap();
+        let chain_name = params.chain_name.clone();
+
+        let new_network_params = NewNetworkParams {
+            chain_id: params.chain_id.try_into().unwrap(),
+            name: chain_name.clone(),
+            explorer_url: params.block_explorer_urls.first().map(|u| u.to_string()),
+            http_url: params
+                .rpc_urls
+                .iter()
+                .find(|s| s.scheme().starts_with("http"))
+                .cloned()
+                .expect("http url not found"),
+            ws_url: params
+                .rpc_urls
+                .iter()
+                .find(|s| s.scheme().starts_with("ws"))
+                .cloned(),
+            currency: params.native_currency.symbol,
+            decimals: params.native_currency.decimals as u32,
+        };
+
+        let deduplication_id = networks
+            .get_network_by_name(&chain_name)
+            .map(|network| network.deduplication_id);
+
         ChainUpdate {
-            network: self.params.unwrap().try_into().unwrap(),
+            network: new_network_params
+                .clone()
+                .into_network(deduplication_id.unwrap_or_default()),
+            new_network_params: Some(new_network_params),
         }
     }
 }

--- a/crates/types/src/dedup_chain_id.rs
+++ b/crates/types/src/dedup_chain_id.rs
@@ -1,0 +1,1 @@
+pub type DedupChainId = (u32, u32);

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,8 +1,10 @@
 mod affinity;
 mod contracts;
+pub mod dedup_chain_id;
 pub mod events;
 mod global_state;
 mod network;
+mod new_network_params;
 mod tokens;
 pub mod transactions;
 pub mod ui_events;
@@ -12,6 +14,7 @@ pub use contracts::{Contract, ContractWithAbi};
 pub use events::Event;
 pub use global_state::GlobalState;
 pub use network::Network;
+pub use new_network_params::NewNetworkParams;
 pub use tokens::{
     Erc1155Token, Erc1155TokenData, Erc721Collection, Erc721Token, Erc721TokenData,
     Erc721TokenDetails, TokenBalance, TokenMetadata,

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -7,8 +7,11 @@ use alloy::{
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::dedup_chain_id::DedupChainId;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Network {
+    pub deduplication_id: u32,
     pub name: String,
     pub chain_id: u32,
     pub explorer_url: Option<String>,
@@ -19,8 +22,9 @@ pub struct Network {
 }
 
 impl Network {
-    pub fn mainnet() -> Self {
+    pub fn mainnet(deduplication_id: u32) -> Self {
         Self {
+            deduplication_id,
             name: String::from("Mainnet"),
             chain_id: 1,
             explorer_url: Some(String::from("https://etherscan.io/search?q=")),
@@ -31,8 +35,9 @@ impl Network {
         }
     }
 
-    pub fn sepolia() -> Self {
+    pub fn sepolia(deduplication_id: u32) -> Self {
         Self {
+            deduplication_id,
             name: String::from("Sepolia"),
             chain_id: 11155111,
             explorer_url: Some(String::from("https://sepolia.etherscan.io/search?q=")),
@@ -43,8 +48,9 @@ impl Network {
         }
     }
 
-    pub fn anvil() -> Self {
+    pub fn anvil(deduplication_id: u32) -> Self {
         Self {
+            deduplication_id,
             name: String::from("Anvil"),
             chain_id: 31337,
             explorer_url: None,
@@ -56,7 +62,11 @@ impl Network {
     }
 
     pub fn all_default() -> Vec<Self> {
-        vec![Self::anvil(), Self::mainnet(), Self::sepolia()]
+        vec![Self::anvil(0), Self::mainnet(0), Self::sepolia(0)]
+    }
+
+    pub fn internal_id(&self) -> DedupChainId {
+        (self.chain_id, self.deduplication_id)
     }
 
     pub fn chain_id_hex(&self) -> String {

--- a/crates/types/src/new_network_params.rs
+++ b/crates/types/src/new_network_params.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::Network;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NewNetworkParams {
+    pub name: String,
+    pub chain_id: u32,
+    pub explorer_url: Option<String>,
+    pub http_url: Url,
+    pub ws_url: Option<Url>,
+    pub currency: String,
+    pub decimals: u32,
+}
+
+impl NewNetworkParams {
+    pub fn into_network(self, deduplication_id: u32) -> Network {
+        Network {
+            deduplication_id,
+            name: self.name,
+            chain_id: self.chain_id,
+            explorer_url: self.explorer_url,
+            http_url: self.http_url,
+            ws_url: self.ws_url,
+            currency: self.currency,
+            decimals: self.decimals,
+        }
+    }
+}


### PR DESCRIPTION
Why:
* #1040

How:
* Adding a new field to the `Network` struct, `deduplication_id`
  intended to distinguish between multiple chains with the same chain
  id
* Adding a `internal_id` function to `Networks` to retrieve the tuple
  compose of chain id and deduplication id
* Adding `get_network_by_name` and `chain_id_count` to `Networks`
* Updating `ChainAdd` and `ChainUpdate` functions to take into account
  the deduplication id
* Adding a migration to handle the update to `networks.json`
