### PR TITLE
Fix dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      update-types:
-        - ["version-update:semver-patch"]
+      - update-types: ["version-update:semver-patch"]
     groups:
       alloy:
         patterns:


### PR DESCRIPTION
Why:
* CI action for dependabot was failing with `The property '#/updates/0/ignore' of type object did not match the following type: array`

How:
* Fixing the syntax of the `ignore` field
