### PR TITLE
Refactor Networks to SerializedNetworks

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -8,7 +8,6 @@ mod error;
 /// the ChaCha20poly1305 scheme to encrypt the data.
 use aead::{rand_core::RngCore as _, KeyInit, OsRng};
 use chacha20poly1305::XChaCha20Poly1305;
-use rand::RngCore;
 use zeroize::Zeroize;
 
 use self::error::CryptoResult;

--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,5 +1,4 @@
 use ethui_types::{GlobalState, Network};
-use url::Url;
 
 use super::{Networks, Result};
 
@@ -14,7 +13,7 @@ pub async fn networks_get_current() -> Result<Network> {
 pub async fn networks_get_list() -> Result<Vec<Network>> {
     let networks = Networks::read().await;
 
-    Ok(networks.networks.values().cloned().collect())
+    Ok(networks.inner.networks.values().cloned().collect())
 }
 
 #[tauri::command]

--- a/crates/networks/src/init.rs
+++ b/crates/networks/src/init.rs
@@ -12,6 +12,8 @@ use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::SerializedNetworks;
+
 use super::Networks;
 
 static NETWORKS: OnceCell<RwLock<Networks>> = OnceCell::new();
@@ -32,17 +34,26 @@ pub async fn init(pathbuf: PathBuf) {
 
         let res: PersistedNetworks = serde_json::from_reader(reader).unwrap();
 
-        Networks {
+        let networks = SerializedNetworks {
             networks: res.networks,
             current: res.current,
+        };
+
+        Networks {
+            inner: networks,
             file: pathbuf,
         }
     } else {
         let networks = Network::all_default();
         let current = networks[0].name.clone();
-        Networks {
+
+        let networks = SerializedNetworks {
             networks: networks.into_iter().map(|n| (n.name.clone(), n)).collect(),
             current,
+        };
+
+        Networks {
+            inner: networks,
             file: pathbuf,
         }
     };


### PR DESCRIPTION
Why:
* In preparation for a future change, the Networks struct needed to be
  refactored to not include the path the to file where its contents are
  read

How:
* Adding a `SerializedNetworks` struct to be used as the `inner` value
  of the `Networks` struct
* Updating all the calls and references to the `Networks` struct to the
  new structure
