### PR TITLE
Add dedup_id migration to affinities

### DIFF
--- a/crates/connections/src/commands.rs
+++ b/crates/connections/src/commands.rs
@@ -11,7 +11,7 @@ pub async fn connections_affinity_for(domain: String) -> Affinity {
 #[tauri::command]
 pub async fn connections_set_affinity(domain: &str, affinity: Affinity) -> Result<()> {
     let new_chain_id = match affinity {
-        Affinity::Sticky(chain_id) => {
+        Affinity::Sticky((chain_id, _dedup_id)) => {
             if !Networks::read().await.validate_chain_id(chain_id) {
                 return Err(Error::InvalidChainId(chain_id));
             }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -55,7 +55,7 @@ impl Ctx {
             match self.get_affinity().await {
                 // If affinity is not set, or sticky, update local affinity, and publish event
                 Affinity::Unset | Affinity::Sticky(_) => {
-                    let affinity = new_chain_id.into();
+                    let affinity = (new_chain_id, 0).into();
                     self.set_affinity(affinity).await?;
 
                     ethui_broadcast::chain_changed(new_chain_id, self.domain.clone(), affinity)
@@ -77,7 +77,7 @@ impl Ctx {
 
     pub async fn chain_id(&self) -> u32 {
         match self.get_affinity().await {
-            Affinity::Sticky(chain_id) => chain_id,
+            Affinity::Sticky((chain_id, _dedup_id)) => chain_id,
             _ => Networks::read().await.get_current().chain_id,
         }
     }

--- a/crates/connections/src/migrations.rs
+++ b/crates/connections/src/migrations.rs
@@ -7,20 +7,37 @@ use serde::{Deserialize, Serialize};
 use serde_constant::ConstI64;
 use serde_json::json;
 
-pub type LatestVersion = ConstI64<1>;
+pub type LatestVersion = ConstI64<2>;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 enum Versions {
     V0(SerializedStoreV0),
-    V1(SerializedStore),
+    V1(SerializedStoreV1),
+    V2(SerializedStore),
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct SerializedStoreV0 {
-    affinities: HashMap<String, Affinity>,
+    affinities: HashMap<String, AffinityV0>,
     version: ConstI64<0>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct SerializedStoreV1 {
+    affinities: HashMap<String, AffinityV0>,
+    version: ConstI64<1>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AffinityV0 {
+    #[default]
+    Unset,
+    Global,
+    Sticky(u32),
 }
 
 pub(crate) fn load_and_migrate(pathbuf: &PathBuf) -> Result<Store> {
@@ -48,22 +65,42 @@ pub(crate) fn load_and_migrate(pathbuf: &PathBuf) -> Result<Store> {
 
 fn run_migrations(store: Versions) -> SerializedStore {
     match store {
-        Versions::V0(v0) => SerializedStore {
+        Versions::V0(v0) => run_migrations(Versions::V1(SerializedStoreV1 {
             affinities: v0.affinities,
             version: ConstI64,
+        })),
+        Versions::V1(v1) => SerializedStore {
+            affinities: migrate_affinities_from_v1_to_v2(v1.affinities),
+            version: ConstI64,
         },
-        Versions::V1(latest) => latest,
+        Versions::V2(latest) => latest,
     }
+}
+
+fn migrate_affinities_from_v1_to_v2(
+    affinities: HashMap<String, AffinityV0>,
+) -> HashMap<String, Affinity> {
+    affinities
+        .into_iter()
+        .map(|(domain, affinity)| match affinity {
+            AffinityV0::Sticky(chain_id) => (domain, Affinity::Sticky((chain_id, 0))),
+            AffinityV0::Unset => (domain, Affinity::Unset),
+            AffinityV0::Global => (domain, Affinity::Global),
+        })
+        .collect::<HashMap<String, Affinity>>()
 }
 
 #[cfg(test)]
 mod tests {
+    use ethui_types::Affinity;
     use serde_json::json;
     use std::{
         fs::File,
         io::{BufReader, Write},
     };
     use tempfile::NamedTempFile;
+
+    use crate::store::SerializedStore;
 
     use super::load_and_migrate;
 
@@ -87,15 +124,15 @@ mod tests {
             let reader = BufReader::new(file);
 
             let updated_store: serde_json::Value = serde_json::from_reader(reader).unwrap();
-            assert_eq!(updated_store["version"], 1);
+            assert_eq!(updated_store["version"], 2);
         }
     }
 
     #[test]
-    fn it_returns_v1_from_v1() {
+    fn it_returns_v2_from_v2() {
         let mut tempfile = NamedTempFile::new().unwrap();
-        let store_v0 = json!({
-            "version": 1,
+        let store = json!({
+            "version": 2,
             "affinities": {
                 "chainlist.org": "global",
                 "etherscan.io": "global",
@@ -105,14 +142,14 @@ mod tests {
             }
         });
 
-        write!(tempfile, "{}", store_v0).unwrap();
+        write!(tempfile, "{}", store).unwrap();
 
         if let Ok(_store) = load_and_migrate(&tempfile.path().to_path_buf()) {
             let file = File::open(tempfile.path()).unwrap();
             let reader = BufReader::new(file);
 
             let updated_store: serde_json::Value = serde_json::from_reader(reader).unwrap();
-            assert_eq!(updated_store["version"], 1);
+            assert_eq!(updated_store["version"], 2);
         }
     }
 
@@ -135,5 +172,32 @@ mod tests {
         let result = load_and_migrate(&tempfile.path().to_path_buf());
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn it_migrates_affinities_to_include_internal_id() {
+        let mut tempfile = NamedTempFile::new().unwrap();
+        let store_v0 = json!({
+            "version": 1,
+            "affinities": {
+                "chainlist.org": "global",
+                "etherscan.io": "global",
+                "localhost": {
+                    "sticky": 313337
+                },
+            }
+        });
+
+        write!(tempfile, "{}", store_v0).unwrap();
+
+        if let Ok(_store) = load_and_migrate(&tempfile.path().to_path_buf()) {
+            let file = File::open(tempfile.path()).unwrap();
+            let reader = BufReader::new(file);
+
+            let updated_store: SerializedStore = serde_json::from_reader(reader).unwrap();
+            let localhost = updated_store.affinities.get("localhost").unwrap();
+
+            assert_eq!(localhost, &Affinity::Sticky((313337, 0)));
+        }
     }
 }

--- a/crates/connections/src/store.rs
+++ b/crates/connections/src/store.rs
@@ -61,6 +61,6 @@ impl Store {
     pub(crate) fn on_chain_removed(&mut self, chain_id: u32) {
         self.inner
             .affinities
-            .retain(|_, affinity| *affinity != chain_id.into());
+            .retain(|_, affinity| *affinity != (chain_id, 0).into());
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -205,6 +205,9 @@ impl Handler {
         let chain_id_str = params[0].get("chainId").unwrap().clone();
         let new_chain_id = u32::from_str_radix(&chain_id_str[2..], 16).unwrap();
 
+        // TODO future work
+        // multiple netowrks with same chain id should display a dialog so user can select which
+        // network to switch to
         Ok(ctx
             .switch_chain(new_chain_id)
             .await

--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -19,6 +19,8 @@ impl ChainAdd {
 
     #[tracing::instrument(skip(self))]
     pub async fn run(self) -> Result<()> {
+        // TODO how to handle dedup_id
+        // if the network already exists, we may want to add a new one anyway
         if self.already_exists().await {
             info!("Network already exists");
             return Ok(());

--- a/crates/types/src/affinity.rs
+++ b/crates/types/src/affinity.rs
@@ -1,17 +1,19 @@
 use serde::{Deserialize, Serialize};
 
+use crate::dedup_chain_id::DedupChainId;
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Affinity {
     #[default]
     Unset,
     Global,
-    Sticky(u32),
+    Sticky(DedupChainId),
 }
 
-impl From<u32> for Affinity {
-    fn from(chain_id: u32) -> Self {
-        Affinity::Sticky(chain_id)
+impl From<DedupChainId> for Affinity {
+    fn from(internal_id: DedupChainId) -> Self {
+        Affinity::Sticky(internal_id)
     }
 }
 

--- a/gui/src/routes/home/_l/connections.tsx
+++ b/gui/src/routes/home/_l/connections.tsx
@@ -79,7 +79,7 @@ function AffinityForm({ domain }: { domain: string }) {
     if (current === "global" || current === "unset") {
       setCurrentNetwork(currentGlobalNetwork);
     } else {
-      setCurrentNetwork(networks.find((n) => n.chain_id === current.sticky));
+      setCurrentNetwork(networks.find((n) => n.chain_id === current.sticky[0]));
     }
   }, [current, networks, currentGlobalNetwork]);
 
@@ -87,7 +87,7 @@ function AffinityForm({ domain }: { domain: string }) {
   const handleChange = (value: string) => {
     let affinity: Affinity = "global";
     if (value !== "global") {
-      affinity = { sticky: Number.parseInt(value) };
+      affinity = { sticky: [Number.parseInt(value), 0] };
     }
     invoke("connections_set_affinity", {
       domain,

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -105,4 +105,4 @@ export interface Peer {
   favicon: string;
 }
 
-export type Affinity = { sticky: number } | "global" | "unset";
+export type Affinity = { sticky: [number, number] } | "global" | "unset";


### PR DESCRIPTION
Why:
* We need to include the dedup id to the affinities

How:
* Adding a migration to replace the chain_id with the internal_id
* Replacing chain_id with the new internal_id in the affinities
  reference
