### PR TITLE
Update new release download url

### DIFF
--- a/gui/src/hooks/useNoticeNewVersion.tsx
+++ b/gui/src/hooks/useNoticeNewVersion.tsx
@@ -27,11 +27,7 @@ export function useNoticeNewVersion() {
       title: "New release available",
       action: (
         <ToastAction altText="Set key" asChild>
-          <a
-            href="https://github.com/ethui/ethui/releases"
-            target="_blank"
-            rel="noreferrer"
-          >
+          <a href="https://ethui.dev" target="_blank" rel="noreferrer">
             Download
           </a>
         </ToastAction>


### PR DESCRIPTION
Why:
* The Download button warning about new releases should point to the new
  landing page, https://ethui.dev

How:
* Updating the URL
