### PR TITLE
Replacing `chain_id` as the network identifier with `internal_id`

### DIFF
--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ethui_types::{ui_events, Address, Affinity, Network, B256};
+use ethui_types::{ui_events, Address, Affinity, DedupChainId, Network, B256};
 pub use internal_msgs::*;
 use once_cell::sync::Lazy;
 use tokio::sync::{broadcast, oneshot, Mutex, RwLock};
@@ -9,7 +9,7 @@ pub use ui_msgs::*;
 /// Supported messages
 #[derive(Debug, Clone)]
 pub enum InternalMsg {
-    ChainChanged(u32, Option<String>, Affinity),
+    ChainChanged(DedupChainId, Option<String>, Affinity),
     AccountsChanged(Vec<Address>),
     SettingsUpdated,
 
@@ -60,8 +60,12 @@ mod internal_msgs {
     }
 
     /// Broadcasts `ChainChanged` events
-    pub async fn chain_changed(chain_id: u32, domain: Option<String>, affinity: Affinity) {
-        send(ChainChanged(chain_id, domain, affinity)).await;
+    pub async fn chain_changed(
+        internal_id: DedupChainId,
+        domain: Option<String>,
+        affinity: Affinity,
+    ) {
+        send(ChainChanged(internal_id, domain, affinity)).await;
     }
 
     /// Broadcasts `AccountsChanged` events

--- a/crates/connections/src/commands.rs
+++ b/crates/connections/src/commands.rs
@@ -10,18 +10,18 @@ pub async fn connections_affinity_for(domain: String) -> Affinity {
 
 #[tauri::command]
 pub async fn connections_set_affinity(domain: &str, affinity: Affinity) -> Result<()> {
-    let new_chain_id = match affinity {
-        Affinity::Sticky((chain_id, _dedup_id)) => {
+    let internal_id = match affinity {
+        Affinity::Sticky((chain_id, deduplication_id)) => {
             if !Networks::read().await.validate_chain_id(chain_id) {
                 return Err(Error::InvalidChainId(chain_id));
             }
-            chain_id
+            (chain_id, deduplication_id)
         }
-        _ => Networks::read().await.get_current().chain_id,
+        _ => Networks::read().await.get_current().internal_id(),
     };
 
     Store::write().await.set_affinity(domain, affinity)?;
-    ethui_broadcast::chain_changed(new_chain_id, Some(domain.into()), affinity).await;
+    ethui_broadcast::chain_changed(internal_id, Some(domain.into()), affinity).await;
 
     Ok(())
 }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -55,17 +55,24 @@ impl Ctx {
             match self.get_affinity().await {
                 // If affinity is not set, or sticky, update local affinity, and publish event
                 Affinity::Unset | Affinity::Sticky(_) => {
+                    // TODO replace 0 with dedup_id
                     let affinity = (new_chain_id, 0).into();
                     self.set_affinity(affinity).await?;
 
-                    ethui_broadcast::chain_changed(new_chain_id, self.domain.clone(), affinity)
-                        .await;
+                    ethui_broadcast::chain_changed(
+                        // TODO replace 0 with dedup_id
+                        (new_chain_id, 0),
+                        self.domain.clone(),
+                        affinity,
+                    )
+                    .await;
                 }
 
                 // If current affinity is global, there's nothing to update on this Ctx, and the
                 // domain is irrelevant in the update,
                 Affinity::Global => {
-                    ethui_broadcast::chain_changed(new_chain_id, None, Affinity::Global).await;
+                    // TODO replace 0 with dedup_id
+                    ethui_broadcast::chain_changed((new_chain_id, 0), None, Affinity::Global).await;
                 }
             };
 

--- a/crates/connections/src/init.rs
+++ b/crates/connections/src/init.rs
@@ -47,7 +47,7 @@ async fn receiver() -> ! {
 
             if let NetworkRemoved(network) = msg {
                 let mut store = Store::write().await;
-                store.on_chain_removed(network.chain_id);
+                store.on_chain_removed(network.internal_id());
             }
         }
     }

--- a/crates/connections/src/store.rs
+++ b/crates/connections/src/store.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ethui_types::Affinity;
+use ethui_types::{Affinity, DedupChainId};
 use serde::{Deserialize, Serialize};
 
 use crate::{migrations::LatestVersion, Result};
@@ -58,9 +58,9 @@ impl Store {
 
     /// Whenever a chain is removed, we need to clear all affinities to that chain
     /// otherwise, new connections from the same website will fail
-    pub(crate) fn on_chain_removed(&mut self, chain_id: u32) {
+    pub(crate) fn on_chain_removed(&mut self, internal_id: DedupChainId) {
         self.inner
             .affinities
-            .retain(|_, affinity| *affinity != (chain_id, 0).into());
+            .retain(|_, affinity| *affinity != internal_id.into());
     }
 }

--- a/crates/networks/src/init.rs
+++ b/crates/networks/src/init.rs
@@ -57,11 +57,14 @@ async fn receiver() -> ! {
         if let Ok(msg) = rx.recv().await {
             use InternalMsg::*;
 
-            if let ChainChanged(chain_id, _domain, affinity) = msg {
+            if let ChainChanged(internal_id, _domain, affinity) = msg {
                 ethui_broadcast::ui_notify(UINotify::PeersUpdated).await;
                 if affinity.is_global() || affinity.is_unset() {
                     // TODO: handle this error
-                    let _ = Networks::write().await.set_current_by_id(chain_id).await;
+                    let _ = Networks::write()
+                        .await
+                        .set_current_by_internal_id(internal_id)
+                        .await;
                 }
             }
         }

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -208,6 +208,16 @@ impl Networks {
             .count() as u32
     }
 
+    pub fn get_lowest_dedup_id(&self, chain_id: u32) -> u32 {
+        self.inner
+            .networks
+            .values()
+            .filter(|network| network.chain_id == chain_id)
+            .map(|network| network.deduplication_id)
+            .min()
+            .unwrap_or(0)
+    }
+
     async fn on_network_changed(&self) -> Result<()> {
         // TODO: check domain
         self.notify_peers();

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -54,7 +54,9 @@ impl ChainUpdate {
                 DialogMsg::Data(msg) => {
                     if let Some("accept") = msg.as_str() {
                         let mut networks = Networks::write().await;
-                        networks.set_current_by_id(self.network.chain_id).await?;
+                        networks
+                            .set_current_by_internal_id(self.network.internal_id())
+                            .await?;
                         break;
                     }
                 }

--- a/crates/types/src/affinity.rs
+++ b/crates/types/src/affinity.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::dedup_chain_id::DedupChainId;
+use crate::DedupChainId;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ui_events;
 pub use affinity::Affinity;
 pub use alloy::primitives::{address, Address, B256, U256, U64};
 pub use contracts::{Contract, ContractWithAbi};
+pub use dedup_chain_id::DedupChainId;
 pub use events::Event;
 pub use global_state::GlobalState;
 pub use network::Network;

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -7,7 +7,7 @@ use alloy::{
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::dedup_chain_id::DedupChainId;
+use crate::DedupChainId;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Network {

--- a/crates/ws/src/init.rs
+++ b/crates/ws/src/init.rs
@@ -35,10 +35,10 @@ async fn receiver() -> ! {
             use InternalMsg::*;
 
             match msg {
-                ChainChanged(chain_id, domain, affinity) => {
+                ChainChanged(internal_id, domain, affinity) => {
                     Peers::read()
                         .await
-                        .broadcast_chain_changed(chain_id, domain, affinity)
+                        .broadcast_chain_changed(internal_id, domain, affinity)
                         .await
                 }
                 AccountsChanged(accounts) => {

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr};
 
 use ethui_networks::Networks;
-use ethui_types::{Address, Affinity, GlobalState, UINotify};
+use ethui_types::{Address, Affinity, DedupChainId, GlobalState, UINotify};
 use serde::Serialize;
 use serde_json::json;
 use tokio::sync::mpsc;
@@ -101,10 +101,12 @@ impl Peers {
     /// Broadcasts a `chainChanged` event to all peers
     pub async fn broadcast_chain_changed(
         &self,
-        chain_id: u32,
+        internal_id: DedupChainId,
         domain: Option<String>,
         affinity: Affinity,
     ) {
+        let chain_id = internal_id.0;
+
         if Networks::read().await.validate_chain_id(chain_id) {
             let msg = json!({
                 "method": "chainChanged",
@@ -120,7 +122,8 @@ impl Peers {
                     tracing::info!(
                         event = "peer chain changed",
                         domain = peer.domain(),
-                        chain_id
+                        chain_id,
+                        dedup_id = internal_id.1,
                     );
                     peer.sender
                         .send(serde_json::to_value(&msg).unwrap())


### PR DESCRIPTION
Why:
* Solves #1041

How:
* Adding `set_current_by_internal_id` and replacing some usages of
  `set_current_by_id`
* Updating `ChainChanged` event to receive the `internal_id` tuple
* Updating affinities and networks to use `internal_id` instead of
  `chain_id`
