### PR TITLE
Refactor DedupChainId into a struct

### DIFF
--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -61,11 +61,11 @@ mod internal_msgs {
 
     /// Broadcasts `ChainChanged` events
     pub async fn chain_changed(
-        internal_id: DedupChainId,
+        dedup_chain_id: DedupChainId,
         domain: Option<String>,
         affinity: Affinity,
     ) {
-        send(ChainChanged(internal_id, domain, affinity)).await;
+        send(ChainChanged(dedup_chain_id, domain, affinity)).await;
     }
 
     /// Broadcasts `AccountsChanged` events

--- a/crates/connections/src/commands.rs
+++ b/crates/connections/src/commands.rs
@@ -10,18 +10,21 @@ pub async fn connections_affinity_for(domain: String) -> Affinity {
 
 #[tauri::command]
 pub async fn connections_set_affinity(domain: &str, affinity: Affinity) -> Result<()> {
-    let internal_id = match affinity {
-        Affinity::Sticky((chain_id, deduplication_id)) => {
+    let dedup_chain_id = match affinity {
+        Affinity::Sticky(dedup_chain_id) => {
+            let chain_id = dedup_chain_id.chain_id();
+
             if !Networks::read().await.validate_chain_id(chain_id) {
                 return Err(Error::InvalidChainId(chain_id));
             }
-            (chain_id, deduplication_id)
+
+            dedup_chain_id
         }
         _ => Networks::read().await.get_current().internal_id(),
     };
 
     Store::write().await.set_affinity(domain, affinity)?;
-    ethui_broadcast::chain_changed(internal_id, Some(domain.into()), affinity).await;
+    ethui_broadcast::chain_changed(dedup_chain_id, Some(domain.into()), affinity).await;
 
     Ok(())
 }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -1,5 +1,5 @@
 use ethui_networks::Networks;
-use ethui_types::{Affinity, GlobalState, Network};
+use ethui_types::{Affinity, DedupChainId, GlobalState, Network};
 
 use crate::{
     permissions::{Permission, PermissionRequest, RequestedPermission},
@@ -56,22 +56,19 @@ impl Ctx {
             match self.get_affinity().await {
                 // If affinity is not set, or sticky, update local affinity, and publish event
                 Affinity::Unset | Affinity::Sticky(_) => {
-                    let affinity = (new_chain_id, dedup_id).into();
+                    let internal_id: DedupChainId = (new_chain_id, 0).into();
+                    let affinity = internal_id.into();
                     self.set_affinity(affinity).await?;
 
-                    ethui_broadcast::chain_changed(
-                        (new_chain_id, dedup_id),
-                        self.domain.clone(),
-                        affinity,
-                    )
-                    .await;
+                    ethui_broadcast::chain_changed(internal_id, self.domain.clone(), affinity)
+                        .await;
                 }
 
                 // If current affinity is global, there's nothing to update on this Ctx, and the
                 // domain is irrelevant in the update,
                 Affinity::Global => {
                     ethui_broadcast::chain_changed(
-                        (new_chain_id, dedup_id),
+                        (new_chain_id, dedup_id).into(),
                         None,
                         Affinity::Global,
                     )
@@ -87,7 +84,7 @@ impl Ctx {
 
     pub async fn chain_id(&self) -> u32 {
         match self.get_affinity().await {
-            Affinity::Sticky((chain_id, _dedup_id)) => chain_id,
+            Affinity::Sticky(dedup_chain_id) => dedup_chain_id.chain_id(),
             _ => Networks::read().await.get_current().chain_id,
         }
     }

--- a/crates/connections/src/migrations.rs
+++ b/crates/connections/src/migrations.rs
@@ -197,7 +197,7 @@ mod tests {
             let updated_store: SerializedStore = serde_json::from_reader(reader).unwrap();
             let localhost = updated_store.affinities.get("localhost").unwrap();
 
-            assert_eq!(localhost, &Affinity::Sticky((313337, 0)));
+            assert_eq!(localhost, &Affinity::Sticky((313337, 0).into()));
         }
     }
 }

--- a/crates/connections/src/migrations.rs
+++ b/crates/connections/src/migrations.rs
@@ -83,7 +83,7 @@ fn migrate_affinities_from_v1_to_v2(
     affinities
         .into_iter()
         .map(|(domain, affinity)| match affinity {
-            AffinityV0::Sticky(chain_id) => (domain, Affinity::Sticky((chain_id, 0))),
+            AffinityV0::Sticky(chain_id) => (domain, Affinity::Sticky((chain_id, 0).into())),
             AffinityV0::Unset => (domain, Affinity::Unset),
             AffinityV0::Global => (domain, Affinity::Global),
         })

--- a/crates/networks/src/migrations.rs
+++ b/crates/networks/src/migrations.rs
@@ -245,7 +245,7 @@ mod tests {
             let updated_networks: SerializedNetworks = serde_json::from_reader(reader).unwrap();
             let mainnet = updated_networks.networks.get("Mainnet").unwrap();
 
-            assert_eq!(mainnet.internal_id(), (mainnet.chain_id, 0));
+            assert_eq!(mainnet.internal_id(), (mainnet.chain_id, 0).into());
         }
     }
 }

--- a/crates/types/src/affinity.rs
+++ b/crates/types/src/affinity.rs
@@ -11,12 +11,6 @@ pub enum Affinity {
     Sticky(DedupChainId),
 }
 
-impl From<(u32, u32)> for Affinity {
-    fn from(internal_id: (u32, u32)) -> Self {
-        Affinity::Sticky(internal_id.into())
-    }
-}
-
 impl From<DedupChainId> for Affinity {
     fn from(internal_id: DedupChainId) -> Self {
         Affinity::Sticky(internal_id)

--- a/crates/types/src/affinity.rs
+++ b/crates/types/src/affinity.rs
@@ -11,6 +11,12 @@ pub enum Affinity {
     Sticky(DedupChainId),
 }
 
+impl From<(u32, u32)> for Affinity {
+    fn from(internal_id: (u32, u32)) -> Self {
+        Affinity::Sticky(internal_id.into())
+    }
+}
+
 impl From<DedupChainId> for Affinity {
     fn from(internal_id: DedupChainId) -> Self {
         Affinity::Sticky(internal_id)

--- a/crates/types/src/dedup_chain_id.rs
+++ b/crates/types/src/dedup_chain_id.rs
@@ -1,1 +1,32 @@
-pub type DedupChainId = (u32, u32);
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DedupChainId {
+    chain_id: u32,
+    dedup_id: u32,
+}
+
+impl DedupChainId {
+    pub fn chain_id(&self) -> u32 {
+        self.chain_id
+    }
+
+    pub fn dedup_id(&self) -> u32 {
+        self.dedup_id
+    }
+}
+
+impl From<(u32, u32)> for DedupChainId {
+    fn from(internal_id: (u32, u32)) -> Self {
+        DedupChainId {
+            chain_id: internal_id.0,
+            dedup_id: internal_id.1,
+        }
+    }
+}
+
+impl From<DedupChainId> for (u32, u32) {
+    fn from(dedup_chain_id: DedupChainId) -> (u32, u32) {
+        (dedup_chain_id.chain_id, dedup_chain_id.dedup_id)
+    }
+}

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -66,7 +66,7 @@ impl Network {
     }
 
     pub fn internal_id(&self) -> DedupChainId {
-        (self.chain_id, self.deduplication_id)
+        (self.chain_id, self.deduplication_id).into()
     }
 
     pub fn chain_id_hex(&self) -> String {

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -101,11 +101,11 @@ impl Peers {
     /// Broadcasts a `chainChanged` event to all peers
     pub async fn broadcast_chain_changed(
         &self,
-        internal_id: DedupChainId,
+        dedup_chain_id: DedupChainId,
         domain: Option<String>,
         affinity: Affinity,
     ) {
-        let chain_id = internal_id.0;
+        let chain_id = dedup_chain_id.chain_id();
 
         if Networks::read().await.validate_chain_id(chain_id) {
             let msg = json!({
@@ -123,7 +123,7 @@ impl Peers {
                         event = "peer chain changed",
                         domain = peer.domain(),
                         chain_id,
-                        dedup_id = internal_id.1,
+                        dedup_id = dedup_chain_id.dedup_id(),
                     );
                     peer.sender
                         .send(serde_json::to_value(&msg).unwrap())

--- a/packages/types/network.ts
+++ b/packages/types/network.ts
@@ -33,7 +33,7 @@ const rpcAndChainIdSchema = z
 
 export const networkSchema = z.intersection(
   z.object({
-    deduplication_id: z.number(),
+    deduplication_id: z.number().optional(),
     name: z.string().min(1),
     explorer_url: z.string().optional().nullable(),
     ws_url: z.string().nullable().optional(),


### PR DESCRIPTION
Why:
* DedupChainId should be a struct to make it impossible to send a random
  tuple without explicit casting

How:
* Refactoring the `DedupChainId` type into a struct
* Adding `Into` implementations to convert between tuples and this type
* Converting usages of the `DedupChainId` into the struct format
