### PR TITLE
Network migration to use DedupChainId

### DIFF
--- a/crates/connections/src/commands.rs
+++ b/crates/connections/src/commands.rs
@@ -20,7 +20,7 @@ pub async fn connections_set_affinity(domain: &str, affinity: Affinity) -> Resul
 
             dedup_chain_id
         }
-        _ => Networks::read().await.get_current().internal_id(),
+        _ => Networks::read().await.get_current().dedup_chain_id(),
     };
 
     Store::write().await.set_affinity(domain, affinity)?;

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -85,7 +85,7 @@ impl Ctx {
     pub async fn chain_id(&self) -> u32 {
         match self.get_affinity().await {
             Affinity::Sticky(dedup_chain_id) => dedup_chain_id.chain_id(),
-            _ => Networks::read().await.get_current().chain_id,
+            _ => Networks::read().await.get_current().chain_id(),
         }
     }
 

--- a/crates/connections/src/init.rs
+++ b/crates/connections/src/init.rs
@@ -47,7 +47,7 @@ async fn receiver() -> ! {
 
             if let NetworkRemoved(network) = msg {
                 let mut store = Store::write().await;
-                store.on_chain_removed(network.internal_id());
+                store.on_chain_removed(network.dedup_chain_id());
             }
         }
     }

--- a/crates/db/src/init.rs
+++ b/crates/db/src/init.rs
@@ -30,8 +30,8 @@ async fn receiver() -> ! {
             if let NetworkRemoved(network) = msg {
                 let db = get();
 
-                let _ = db.remove_contracts(network.chain_id).await;
-                let _ = db.remove_transactions(network.chain_id).await;
+                let _ = db.remove_contracts(network.chain_id()).await;
+                let _ = db.remove_transactions(network.chain_id()).await;
             }
         }
     }

--- a/crates/networks/src/init.rs
+++ b/crates/networks/src/init.rs
@@ -57,13 +57,13 @@ async fn receiver() -> ! {
         if let Ok(msg) = rx.recv().await {
             use InternalMsg::*;
 
-            if let ChainChanged(internal_id, _domain, affinity) = msg {
+            if let ChainChanged(dedup_chain_id, _domain, affinity) = msg {
                 ethui_broadcast::ui_notify(UINotify::PeersUpdated).await;
                 if affinity.is_global() || affinity.is_unset() {
                     // TODO: handle this error
                     let _ = Networks::write()
                         .await
-                        .set_current_by_internal_id(internal_id)
+                        .set_current_by_dedup_chain_id(dedup_chain_id)
                         .await;
                 }
             }

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -63,7 +63,7 @@ impl Networks {
             .inner
             .networks
             .values()
-            .find(|n| n.chain_id == new_chain_id)
+            .find(|n| n.chain_id() == new_chain_id)
             .unwrap();
 
         self.set_current_by_name(new_network.name.clone()).await?;
@@ -75,12 +75,15 @@ impl Networks {
     /// Changes the currently connected wallet by internal ID
     ///
     /// Broadcasts `chainChanged` to all connections with global or no affinity
-    pub async fn set_current_by_internal_id(&mut self, internal_id: DedupChainId) -> Result<()> {
+    pub async fn set_current_by_dedup_chain_id(
+        &mut self,
+        dedup_chain_id: DedupChainId,
+    ) -> Result<()> {
         let new_network = self
             .inner
             .networks
             .values()
-            .find(|n| n.internal_id() == internal_id)
+            .find(|n| n.dedup_chain_id() == dedup_chain_id)
             .unwrap();
 
         self.set_current_by_name(new_network.name.clone()).await?;
@@ -93,7 +96,7 @@ impl Networks {
         self.inner
             .networks
             .iter()
-            .any(|(_, n)| n.chain_id == chain_id)
+            .any(|(_, n)| n.chain_id() == chain_id)
     }
 
     pub fn get_current(&self) -> &Network {
@@ -108,7 +111,7 @@ impl Networks {
         self.inner
             .networks
             .values()
-            .find(|n| n.chain_id == chain_id)
+            .find(|n| n.chain_id() == chain_id)
             .cloned()
     }
 
@@ -122,7 +125,7 @@ impl Networks {
 
     pub async fn add_network(&mut self, network: NewNetworkParams) -> Result<()> {
         // TODO: need to ensure uniqueness by name, not chain id
-        if self.validate_chain_id(network.chain_id) {
+        if self.validate_chain_id(network.dedup_chain_id.chain_id()) {
             return Err(Error::AlreadyExists);
         }
 
@@ -130,7 +133,7 @@ impl Networks {
             return Err(Error::AlreadyExists);
         }
 
-        let deduplication_id = self.get_chain_id_count(network.chain_id);
+        let deduplication_id = self.get_chain_id_count(network.dedup_chain_id.chain_id());
         let network = network.into_network(deduplication_id);
 
         self.inner
@@ -204,7 +207,7 @@ impl Networks {
         self.inner
             .networks
             .values()
-            .filter(|network| network.chain_id == chain_id)
+            .filter(|network| network.chain_id() == chain_id)
             .count() as u32
     }
 
@@ -212,8 +215,8 @@ impl Networks {
         self.inner
             .networks
             .values()
-            .filter(|network| network.chain_id == chain_id)
-            .map(|network| network.deduplication_id)
+            .filter(|network| network.chain_id() == chain_id)
+            .map(|network| network.dedup_chain_id.dedup_id())
             .min()
             .unwrap_or(0)
     }
@@ -233,7 +236,7 @@ impl Networks {
     fn notify_peers(&self) {
         let current = self.get_current().clone();
         tokio::spawn(async move {
-            ethui_broadcast::chain_changed(current.internal_id(), None, Affinity::Global).await;
+            ethui_broadcast::chain_changed(current.dedup_chain_id(), None, Affinity::Global).await;
         });
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -154,7 +154,7 @@ impl Handler {
         Ok(json!({
             "isUnlocked": true,
             "chainId": network.chain_id_hex(),
-            "networkVersion": network.chain_id.to_string(),
+            "networkVersion": network.chain_id().to_string(),
             "accounts": [address],
         }))
     }

--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -47,7 +47,7 @@ impl ChainAdd {
 
     pub async fn already_exists(&self) -> bool {
         let networks = Networks::read().await;
-        networks.validate_chain_id(self.network.chain_id)
+        networks.validate_chain_id(self.network.dedup_chain_id.chain_id())
     }
 
     pub async fn on_accept(&self) -> Result<()> {
@@ -106,7 +106,8 @@ impl TryFrom<Params> for NewNetworkParams {
     fn try_from(params: Params) -> Result<Self> {
         Ok(Self {
             name: params.chain_name,
-            chain_id: params.chain_id.try_into().unwrap(),
+            // Using 0 for dedup_id since at this time no duplicate chain_id is allowed
+            dedup_chain_id: (params.chain_id.try_into().unwrap(), 0).into(),
             explorer_url: params.block_explorer_urls.first().map(|u| u.to_string()),
             http_url: params
                 .rpc_urls

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -70,7 +70,7 @@ impl SendTransaction {
 
     async fn dialog_and_send(&mut self) -> Result<PendingTransactionBuilder<Ethereum>> {
         let mut params = serde_json::to_value(&self.request).unwrap();
-        params["chainId"] = self.network.chain_id.into();
+        params["chainId"] = self.network.chain_id().into();
         params["walletType"] = self.wallet_type.to_string().into();
 
         let dialog = Dialog::new("tx-review", params);
@@ -120,7 +120,7 @@ impl SendTransaction {
     }
 
     async fn simulate(&self, dialog: &Dialog) -> Result<()> {
-        let chain_id = self.network.chain_id;
+        let chain_id = self.network.chain_id();
         let request = self.simulation_request().await?;
 
         if let Ok(sim) = ethui_simulator::commands::simulator_run(chain_id, request).await {
@@ -168,7 +168,7 @@ impl SendTransaction {
             Some(Box::new(provider))
         } else {
             let signer = wallet
-                .build_signer(self.network.chain_id, &self.wallet_path)
+                .build_signer(self.network.chain_id(), &self.wallet_path)
                 .await?;
             let provider = ProviderBuilder::new()
                 .wallet(signer.to_wallet())

--- a/crates/rpc/src/methods/sign_message.rs
+++ b/crates/rpc/src/methods/sign_message.rs
@@ -77,7 +77,7 @@ impl<'a> SignMessage<'a> {
 
     async fn build_signer(&self) -> Signer {
         self.wallet
-            .build_signer(self.network.chain_id, &self.wallet_path)
+            .build_signer(self.network.chain_id(), &self.wallet_path)
             .await
             .unwrap()
     }

--- a/crates/rpc/src/methods/token_add.rs
+++ b/crates/rpc/src/methods/token_add.rs
@@ -43,7 +43,7 @@ impl TokenAdd {
 
     pub async fn get_current_chain_id(&self) -> u32 {
         let networks = Networks::read().await;
-        networks.get_current().chain_id
+        networks.get_current().chain_id()
     }
 
     pub async fn get_current_wallet_address(&self) -> Address {

--- a/crates/sync/anvil/src/init.rs
+++ b/crates/sync/anvil/src/init.rs
@@ -24,8 +24,16 @@ async fn receiver() -> ! {
             | Ok(InternalMsg::NetworkRemoved(network))
                 if network.is_dev().await =>
             {
-                trace!("resetting anvil listener for chain_id {}", network.chain_id);
-                reset_listener(network.chain_id, network.clone().http_url, network.ws_url()).await
+                trace!(
+                    "resetting anvil listener for chain_id {}",
+                    network.chain_id()
+                );
+                reset_listener(
+                    network.chain_id(),
+                    network.clone().http_url,
+                    network.ws_url(),
+                )
+                .await
             }
             _ => (),
         }

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -42,9 +42,9 @@ impl TryFrom<InternalMsg> for Msg {
             InternalMsg::AddressAdded(addr) => Msg::TrackAddress(addr),
             InternalMsg::AddressRemoved(addr) => Msg::UntrackAddress(addr),
             InternalMsg::CurrentAddressChanged(addr) => Msg::PollAddress(addr),
-            InternalMsg::NetworkAdded(network) => Msg::TrackNetwork(network.chain_id),
-            InternalMsg::NetworkRemoved(network) => Msg::UntrackNetwork(network.chain_id),
-            InternalMsg::CurrentNetworkChanged(network) => Msg::PollNetwork(network.chain_id),
+            InternalMsg::NetworkAdded(network) => Msg::TrackNetwork(network.chain_id()),
+            InternalMsg::NetworkRemoved(network) => Msg::UntrackNetwork(network.chain_id()),
+            InternalMsg::CurrentNetworkChanged(network) => Msg::PollNetwork(network.chain_id()),
             InternalMsg::FetchFullTxSync(chain_id, hash, oneshot) => {
                 Msg::FetchFullTxSync(chain_id, hash, oneshot)
             }

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -11,9 +11,8 @@ use crate::DedupChainId;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Network {
-    pub deduplication_id: u32,
+    pub dedup_chain_id: DedupChainId,
     pub name: String,
-    pub chain_id: u32,
     pub explorer_url: Option<String>,
     pub http_url: Url,
     pub ws_url: Option<Url>,
@@ -24,9 +23,8 @@ pub struct Network {
 impl Network {
     pub fn mainnet(deduplication_id: u32) -> Self {
         Self {
-            deduplication_id,
+            dedup_chain_id: (1, deduplication_id).into(),
             name: String::from("Mainnet"),
-            chain_id: 1,
             explorer_url: Some(String::from("https://etherscan.io/search?q=")),
             http_url: Url::parse("https://eth.llamarpc.com").unwrap(),
             ws_url: None,
@@ -37,9 +35,8 @@ impl Network {
 
     pub fn sepolia(deduplication_id: u32) -> Self {
         Self {
-            deduplication_id,
+            dedup_chain_id: (11155111, deduplication_id).into(),
             name: String::from("Sepolia"),
-            chain_id: 11155111,
             explorer_url: Some(String::from("https://sepolia.etherscan.io/search?q=")),
             http_url: Url::parse("https://ethereum-sepolia-rpc.publicnode.com").unwrap(),
             ws_url: None,
@@ -50,9 +47,8 @@ impl Network {
 
     pub fn anvil(deduplication_id: u32) -> Self {
         Self {
-            deduplication_id,
+            dedup_chain_id: (31337, deduplication_id).into(),
             name: String::from("Anvil"),
-            chain_id: 31337,
             explorer_url: None,
             http_url: Url::parse("http://localhost:8545").unwrap(),
             ws_url: Some(Url::parse("ws://localhost:8545").unwrap()),
@@ -65,12 +61,16 @@ impl Network {
         vec![Self::anvil(0), Self::mainnet(0), Self::sepolia(0)]
     }
 
-    pub fn internal_id(&self) -> DedupChainId {
-        (self.chain_id, self.deduplication_id).into()
+    pub fn dedup_chain_id(&self) -> DedupChainId {
+        self.dedup_chain_id
+    }
+
+    pub fn chain_id(&self) -> u32 {
+        self.dedup_chain_id.chain_id()
     }
 
     pub fn chain_id_hex(&self) -> String {
-        format!("0x{:x}", self.chain_id)
+        format!("0x{:x}", self.chain_id())
     }
 
     pub fn ws_url(&self) -> Url {
@@ -82,7 +82,7 @@ impl Network {
     pub async fn is_dev(&self) -> bool {
         let provider = self.get_alloy_provider().await.unwrap();
         // TODO cache node_info for entire chain
-        self.chain_id == 31337 || provider.anvil_node_info().await.is_ok()
+        self.chain_id() == 31337 || provider.anvil_node_info().await.is_ok()
     }
 
     pub async fn get_alloy_provider(
@@ -107,6 +107,6 @@ impl Network {
 
 impl std::fmt::Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}", self.chain_id, self.name)
+        write!(f, "{}-{}", self.chain_id(), self.name)
     }
 }

--- a/crates/types/src/new_network_params.rs
+++ b/crates/types/src/new_network_params.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::Network;
+use crate::{DedupChainId, Network};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct NewNetworkParams {
     pub name: String,
-    pub chain_id: u32,
+    pub dedup_chain_id: DedupChainId,
     pub explorer_url: Option<String>,
     pub http_url: Url,
     pub ws_url: Option<Url>,
@@ -17,9 +17,8 @@ pub struct NewNetworkParams {
 impl NewNetworkParams {
     pub fn into_network(self, deduplication_id: u32) -> Network {
         Network {
-            deduplication_id,
+            dedup_chain_id: (self.dedup_chain_id.chain_id(), deduplication_id).into(),
             name: self.name,
-            chain_id: self.chain_id,
             explorer_url: self.explorer_url,
             http_url: self.http_url,
             ws_url: self.ws_url,

--- a/gui/src/components/AddressView.tsx
+++ b/gui/src/components/AddressView.tsx
@@ -55,7 +55,7 @@ export function AddressView({
       <div className="flex items-center gap-x-1 font-mono text-base">
         {icon && (
           <IconAddress
-            chainId={network.chain_id}
+            chainId={network.dedup_chain_id.chain_id}
             address={address}
             effigy
             className="h-4"

--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -26,7 +26,7 @@ function BalanceETH() {
         balance={balance}
         decimals={currentNetwork.decimals}
         symbol={currentNetwork.currency}
-        chainId={currentNetwork.chain_id}
+        chainId={currentNetwork.dedup_chain_id.chain_id}
       />
     </li>
   );
@@ -50,7 +50,7 @@ function BalancesERC20() {
         balance={BigInt(balance)}
         decimals={metadata?.decimals || 0}
         symbol={metadata?.symbol}
-        chainId={currentNetwork.chain_id}
+        chainId={currentNetwork.dedup_chain_id.chain_id}
       />
     </li>
   ));

--- a/gui/src/components/ERC20View.tsx
+++ b/gui/src/components/ERC20View.tsx
@@ -43,7 +43,7 @@ export function ERC20View({
 
   const blacklist = () => {
     invoke("db_set_erc20_blacklist", {
-      chainId: network.chain_id,
+      chainId: network.dedup_chain_id.chain_id,
       address: contract,
       blacklisted: true,
     });

--- a/gui/src/components/QuickNetworkSelect.tsx
+++ b/gui/src/components/QuickNetworkSelect.tsx
@@ -26,7 +26,7 @@ export function QuickNetworkSelect() {
 
       <SelectContent>
         <SelectGroup>
-          {networks.map(({ chain_id, name }) => (
+          {networks.map(({ dedup_chain_id: { chain_id }, name }) => (
             <SelectItem value={name} key={name}>
               <ChainView chainId={chain_id} name={name} />
             </SelectItem>

--- a/gui/src/hooks/useNoticeAlchemyKeyMissing.tsx
+++ b/gui/src/hooks/useNoticeAlchemyKeyMissing.tsx
@@ -13,7 +13,7 @@ export function useNoticeAlchemyKeyMissing() {
 
   const { data: isSupportedNetwork, isLoading: isLoadingSupportedNetwork } =
     useInvoke<boolean>("sync_alchemy_is_network_supported", {
-      chainId: currentNetwork?.chain_id,
+      chainId: currentNetwork?.dedup_chain_id.chain_id,
     });
 
   const isLoading = !settings || isLoadingSupportedNetwork;

--- a/gui/src/routes/dialog/_l/chain-add.$id.tsx
+++ b/gui/src/routes/dialog/_l/chain-add.$id.tsx
@@ -25,12 +25,15 @@ function ChainAddDialog() {
         <h1 className="font-xl">Add new network</h1>
       </div>
 
-      <ChainView chainId={network.chain_id} name={network.name} />
+      <ChainView
+        chainId={network.dedup_chain_id.chain_id}
+        name={network.name}
+      />
 
       <div className="grid grid-cols-4 gap-5">
         <Datapoint
           label="Chain ID"
-          value={network.chain_id}
+          value={network.dedup_chain_id.chain_id}
           className="col-span-2"
         />
         <Datapoint

--- a/gui/src/routes/dialog/_l/chain-switch.$id.tsx
+++ b/gui/src/routes/dialog/_l/chain-switch.$id.tsx
@@ -23,8 +23,12 @@ function ChainSwitchDialog() {
 
   if (!switchData) return null;
 
-  const from = networks.find((n) => n.chain_id === switchData.oldId);
-  const to = networks.find((n) => n.chain_id === switchData.newId);
+  const from = networks.find(
+    (n) => n.dedup_chain_id.chain_id === switchData.oldId,
+  );
+  const to = networks.find(
+    (n) => n.dedup_chain_id.chain_id === switchData.newId,
+  );
 
   if (!from || !to) return null;
 
@@ -35,9 +39,9 @@ function ChainSwitchDialog() {
       </div>
 
       <div className="flex gap-2 self-center">
-        <ChainView chainId={from.chain_id} name={from.name} />
+        <ChainView chainId={from.dedup_chain_id.chain_id} name={from.name} />
         <span>→</span>
-        <ChainView chainId={to?.chain_id} name={to.name} />
+        <ChainView chainId={to?.dedup_chain_id.chain_id} name={to.name} />
       </div>
 
       <div className="m-2 flex items-center justify-center gap-2">

--- a/gui/src/routes/dialog/_l/erc20-add.$id.tsx
+++ b/gui/src/routes/dialog/_l/erc20-add.$id.tsx
@@ -36,7 +36,7 @@ function ERC20AddDialog() {
           value={
             <div className="m-1 flex flex-col text-center">
               <IconAddress
-                chainId={network.chain_id}
+                chainId={network.dedup_chain_id.chain_id}
                 address={token.metadata.address}
               />
               <span className="self-center">{token.metadata.name}</span>

--- a/gui/src/routes/dialog/_l/tx-review.$id.tsx
+++ b/gui/src/routes/dialog/_l/tx-review.$id.tsx
@@ -69,7 +69,7 @@ function TxReviewDialog() {
   const { id } = Route.useParams();
   const dialog = useDialog<TxRequest>(id);
   const network = useNetworks((s) =>
-    s.networks.find((n) => n.chain_id === dialog.data?.chainId),
+    s.networks.find((n) => n.dedup_chain_id.chain_id === dialog.data?.chainId),
   );
 
   if (!dialog.data || !network) return null;
@@ -181,7 +181,10 @@ function Header({ from, to, network }: HeaderProps) {
         </div>
       </h1>
       <div className="ml-5">
-        <ChainView name={network.name} chainId={network.chain_id} />
+        <ChainView
+          name={network.name}
+          chainId={network.dedup_chain_id.chain_id}
+        />
       </div>
     </div>
   );

--- a/gui/src/routes/home/_l/connections.tsx
+++ b/gui/src/routes/home/_l/connections.tsx
@@ -79,7 +79,9 @@ function AffinityForm({ domain }: { domain: string }) {
     if (current === "global" || current === "unset") {
       setCurrentNetwork(currentGlobalNetwork);
     } else {
-      setCurrentNetwork(networks.find((n) => n.chain_id === current.sticky[0]));
+      setCurrentNetwork(
+        networks.find((n) => n.dedup_chain_id.chain_id === current.sticky[0]),
+      );
     }
   }, [current, networks, currentGlobalNetwork]);
 
@@ -109,7 +111,7 @@ function AffinityForm({ domain }: { domain: string }) {
           <SelectValue>
             {!isGlobal && currentNetwork ? (
               <ChainView
-                chainId={currentNetwork.chain_id}
+                chainId={currentNetwork.dedup_chain_id.chain_id}
                 name={currentNetwork.name}
               />
             ) : (
@@ -123,10 +125,13 @@ function AffinityForm({ domain }: { domain: string }) {
             <SelectItem value="global">Global</SelectItem>
             {networks.map((network) => (
               <SelectItem
-                value={network.chain_id.toString()}
+                value={network.dedup_chain_id.chain_id.toString()}
                 key={network.name}
               >
-                <ChainView chainId={network.chain_id} name={network.name} />
+                <ChainView
+                  chainId={network.dedup_chain_id.chain_id}
+                  name={network.name}
+                />
               </SelectItem>
             ))}
           </SelectGroup>

--- a/gui/src/routes/home/_l/contracts/_l/index.tsx
+++ b/gui/src/routes/home/_l/contracts/_l/index.tsx
@@ -110,7 +110,9 @@ function AddressForm() {
   const form = useForm({
     mode: "onChange",
     resolver: zodResolver(schema),
-    defaultValues: { chainId: currentNetwork?.chain_id?.toString() } as Schema,
+    defaultValues: {
+      chainId: currentNetwork?.dedup_chain_id.chain_id?.toString(),
+    } as Schema,
   });
 
   const onSubmit = (data: FieldValues) => add(data.chainId, data.address);
@@ -122,10 +124,10 @@ function AddressForm() {
       <Form.Select
         label="Network"
         name="chainId"
-        defaultValue={currentNetwork.chain_id.toString()}
+        defaultValue={currentNetwork.dedup_chain_id.chain_id.toString()}
         items={networks}
-        toValue={(n) => n.chain_id.toString()}
-        render={({ chain_id, name }) => (
+        toValue={(n) => n.dedup_chain_id.chain_id.toString()}
+        render={({ dedup_chain_id: { chain_id }, name }) => (
           <ChainView chainId={chain_id} name={name} />
         )}
       />

--- a/gui/src/routes/home/_l/settings/_l/networks/_l/$name.edit.tsx
+++ b/gui/src/routes/home/_l/settings/_l/networks/_l/$name.edit.tsx
@@ -59,7 +59,7 @@ function Content({ network }: { network: Network }) {
           className="[&::-webkit-inner-spin-button]:appearance-none"
           disabled={true}
           label="Chain Id"
-          name="chain_id"
+          name="dedup_chain_id.chain_id"
         />
       </div>
 

--- a/gui/src/routes/home/_l/settings/_l/networks/_l/index.tsx
+++ b/gui/src/routes/home/_l/settings/_l/networks/_l/index.tsx
@@ -19,7 +19,7 @@ function SettingsNetworks() {
   // TODO: add network button
   return (
     <div className="flex flex-wrap gap-2">
-      {networks.map(({ chain_id, name }) => (
+      {networks.map(({ dedup_chain_id: { chain_id }, name }) => (
         <Link
           to={`/home/settings/networks/${name}/edit`}
           key={name}

--- a/gui/src/routes/home/_l/settings/_l/networks/_l/new.tsx
+++ b/gui/src/routes/home/_l/settings/_l/networks/_l/new.tsx
@@ -27,7 +27,7 @@ function Content() {
   });
 
   const httpUrl = form.watch("http_url");
-  const userChainId = form.watch("chain_id");
+  const userChainId = form.watch("dedup_chain_id.chain_id");
 
   useEffect(() => {
     if (!httpUrl) return;
@@ -42,8 +42,8 @@ function Content() {
         );
 
         if (!userChainId) {
-          form.setValue("chain_id", chainId);
-          form.clearErrors("chain_id");
+          form.setValue("dedup_chain_id.chain_id", chainId);
+          form.clearErrors("dedup_chain_id.chain_id");
         }
       } catch (_e) {
         return null;
@@ -56,6 +56,7 @@ function Content() {
   const onSubmit = async (data: Network) => {
     try {
       setLoading(true);
+      data.dedup_chain_id.dedup_id = 0;
       await invoke("networks_add", { network: data });
       setLoading(false);
       router.history.back();
@@ -79,7 +80,7 @@ function Content() {
         <Form.NumberField
           className="[&::-webkit-inner-spin-button]:appearance-none"
           label="Chain Id"
-          name="chain_id"
+          name="dedup_chain_id.chain_id"
         />
       </div>
 

--- a/gui/src/routes/home/_l/settings/_l/tokens.tsx
+++ b/gui/src/routes/home/_l/settings/_l/tokens.tsx
@@ -23,7 +23,7 @@ function SettingsTokens() {
 
   const unhide = (contract: Address) => {
     invoke("db_clear_erc20_blacklist", {
-      chainId: currentNetwork.chain_id,
+      chainId: currentNetwork.dedup_chain_id.chain_id,
       address: contract,
     });
   };
@@ -35,7 +35,10 @@ function SettingsTokens() {
           key={contract}
           className="flex w-full items-center justify-between gap-5"
         >
-          <IconAddress chainId={currentNetwork.chain_id} address={contract} />
+          <IconAddress
+            chainId={currentNetwork.dedup_chain_id.chain_id}
+            address={contract}
+          />
 
           <span className="flex items-center gap-1">
             {metadata?.symbol}

--- a/gui/src/routes/home/_l/transactions.tsx
+++ b/gui/src/routes/home/_l/transactions.tsx
@@ -43,7 +43,7 @@ export const Route = createFileRoute("/home/_l/transactions")({
 
 function Txs() {
   const account = useWallets((s) => s.address);
-  const chainId = useNetworks((s) => s.current?.chain_id);
+  const chainId = useNetworks((s) => s.current?.dedup_chain_id.chain_id);
   const pageSize = 10;
 
   const [items, setItems] = useState<PaginatedTx[]>([]);

--- a/gui/src/store/useBalances.ts
+++ b/gui/src/store/useBalances.ts
@@ -77,7 +77,7 @@ event.listen("balances-updated", async () => {
   );
 
   useNetworks.subscribe(
-    (s) => s.current?.chain_id,
+    (s) => s.current?.dedup_chain_id.chain_id,
     (chainId) => useBalances.getState().setChainId(chainId),
     { fireImmediately: true },
   );

--- a/gui/src/store/useBlacklist.ts
+++ b/gui/src/store/useBlacklist.ts
@@ -68,7 +68,7 @@ event.listen("balances-updated", async () => {
   );
 
   useNetworks.subscribe(
-    (s) => s.current?.chain_id,
+    (s) => s.current?.dedup_chain_id.chain_id,
     (chainId) => useBlacklist.getState().setChainId(chainId),
     { fireImmediately: true },
   );

--- a/gui/src/store/useContracts.ts
+++ b/gui/src/store/useContracts.ts
@@ -99,7 +99,7 @@ event.listen("contracts-updated", async () => {
 });
 
 useNetworks.subscribe(
-  (s) => s.current?.chain_id,
+  (s) => s.current?.dedup_chain_id.chain_id,
   (chainId) => useContracts.getState().setChainId(chainId),
   { fireImmediately: true },
 );

--- a/gui/src/store/useNetworks.tsx
+++ b/gui/src/store/useNetworks.tsx
@@ -61,7 +61,7 @@ const store: StateCreator<Store> = (set, get) => ({
     const actions = (networks || []).map((network) => ({
       id: `${actionId}/${network.name}`,
       text: `${network.name}`,
-      icon: <ChainIcon chainId={network.chain_id} />,
+      icon: <ChainIcon chainId={network.dedup_chain_id.chain_id} />,
       run: () => {
         get().setCurrent(network.name);
       },
@@ -76,7 +76,7 @@ const store: StateCreator<Store> = (set, get) => ({
     if (!current) return false;
 
     return await invoke<boolean>("sync_alchemy_is_network_supported", {
-      chainId: current.chain_id,
+      chainId: current.dedup_chain_id.chain_id,
     });
   },
 });

--- a/packages/types/network.ts
+++ b/packages/types/network.ts
@@ -4,9 +4,12 @@ import { z } from "zod";
 const rpcAndChainIdSchema = z
   .object({
     http_url: z.string().min(1).url(),
-    chain_id: z.coerce.number().positive(),
+    dedup_chain_id: z.object({
+      chain_id: z.coerce.number().positive(),
+      dedup_id: z.coerce.number().optional(),
+    }),
   })
-  .superRefine(async ({ http_url, chain_id }, ctx) => {
+  .superRefine(async ({ http_url, dedup_chain_id: { chain_id } }, ctx) => {
     if (!http_url || !chain_id || http_url === "") return;
 
     try {
@@ -33,7 +36,6 @@ const rpcAndChainIdSchema = z
 
 export const networkSchema = z.intersection(
   z.object({
-    deduplication_id: z.number().optional(),
     name: z.string().min(1),
     explorer_url: z.string().optional().nullable(),
     ws_url: z.string().nullable().optional(),


### PR DESCRIPTION
Why:
* We can use the `DedupChainId` struct to identify a network instead of
  having two separate fields in the `Network` struct

How:
* Adding a migration to update the Network struct to V3
* Updating all the references to the `chain_id` field to be a call
  instead
* Using `dedup_chain_id` in gui to access the `chain_id` field
* Renaming `internal_id` to `dedup_chain_id`
