### PR TITLE
Fixing onboarding migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6641,6 +6647,16 @@ dependencies = [
  "memchr",
  "thiserror 1.0.69",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -10447,7 +10463,7 @@ checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.41",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -10460,7 +10476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
  "bitflags 2.8.0",
- "rustix",
+ "rustix 0.38.41",
  "wayland-backend",
  "wayland-scanner",
 ]

--- a/crates/settings/src/migrations.rs
+++ b/crates/settings/src/migrations.rs
@@ -44,6 +44,8 @@ struct SerializedSettingsV0 {
 
     #[serde(default)]
     rust_log: String,
+
+    version: ConstI64<0>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -184,6 +186,7 @@ impl Default for SerializedSettingsV0 {
             autostart: false,
             start_minimized: false,
             rust_log: "warn".into(),
+            version: ConstI64,
         }
     }
 }


### PR DESCRIPTION
Fixes a bug where the onboarding settings wouldn't be updated because migrations were not properly defined