### PR TITLE
Moving to rust nightly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Z", "threads=16", "-Zshare-generics=y"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       #     ls
       #   shell: bash
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1 libsoup-3.0-dev patchelf libsodium-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -88,7 +88,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1 libsoup-3.0-dev patchelf libsodium-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2

--- a/.mise.toml
+++ b/.mise.toml
@@ -25,7 +25,7 @@ run = "yarn run ext:dev"
 
 [tools]
 node = "22.12.0"
-rust = "stable"
+rust = "nightly"
 
 [env]
 NODE_ENV = "development"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ members = [
 ]
 default-members = ["bin"]
 
+[profile.dev]
+# https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
 [workspace.dependencies]
 ethui-forge = { path = "crates/forge" }
 ethui-crypto = { path = "crates/crypto" }

--- a/crates/forge/src/actor.rs
+++ b/crates/forge/src/actor.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
 use alloy::primitives::Bytes;
 use ethui_types::UINotify;
 use futures::{stream, StreamExt as _};
@@ -12,11 +18,6 @@ use notify_debouncer_full::{
 use tracing::{instrument, trace, warn};
 
 use crate::{abi::ForgeAbi, error::Result, utils};
-use std::{
-    collections::{BTreeMap, HashSet},
-    path::{Path, PathBuf},
-    time::Duration,
-};
 
 #[derive(Default)]
 pub struct Worker {
@@ -110,7 +111,7 @@ impl Message<UpdateContracts> for Worker {
         let contracts_with_code = stream::iter(contracts)
             .map(|(chain_id, address, code)| async move {
                 let code: Option<Bytes> = match code {
-                    Some(code) if code.len() > 0 => Some(code),
+                    Some(code) if !code.is_empty() => Some(code),
                     _ => utils::get_code(chain_id, address).await.ok(),
                 };
 
@@ -343,11 +344,12 @@ impl Worker {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
 
     use anyhow::Result;
     use tempfile::TempDir;
+
+    use super::*;
 
     #[tokio::test]
     pub async fn find_forge_tomls() -> Result<()> {

--- a/crates/rpc/src/methods/sign_message.rs
+++ b/crates/rpc/src/methods/sign_message.rs
@@ -86,7 +86,7 @@ impl<'a> SignMessage<'a> {
 #[derive(Serialize)]
 enum Data {
     Raw(String),
-    Typed(TypedData),
+    Typed(Box<TypedData>),
 }
 
 #[derive(Default)]
@@ -119,7 +119,7 @@ impl<'a> SignMessageBuilder<'a> {
     }
 
     pub fn set_typed_data(mut self, data: TypedData) -> SignMessageBuilder<'a> {
-        self.data = Some(Data::Typed(data));
+        self.data = Some(Data::Typed(Box::new(data)));
         self
     }
 

--- a/crates/types/src/events.rs
+++ b/crates/types/src/events.rs
@@ -8,7 +8,7 @@ use crate::{Address, B256};
 
 #[derive(Debug)]
 pub enum Event {
-    Tx(Tx),
+    Tx(Box<Tx>),
     ContractDeployed(ContractDeployed),
     ERC20Transfer(ERC20Transfer),
     ERC721Transfer(ERC721Transfer),
@@ -74,7 +74,7 @@ impl From<ContractDeployed> for Event {
 
 impl From<Tx> for Event {
     fn from(value: Tx) -> Self {
-        Self::Tx(value)
+        Self::Tx(Box::new(value))
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"


### PR DESCRIPTION
This provides access to a few quality-of-life improvements, such as the ability to use the [new parallel frontend](https://blog.rust-lang.org/2023/11/09/parallel-rustc.html), and [cranelift](https://cranelift.dev/)

in total, this reduces by build times (from scratch) from 1m20s down to 50s!