### PR TITLE
Boxes a large enum variant

### DIFF
--- a/crates/forge/src/actor.rs
+++ b/crates/forge/src/actor.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
 use alloy::primitives::Bytes;
 use ethui_types::UINotify;
 use futures::{stream, StreamExt as _};
@@ -12,11 +18,6 @@ use notify_debouncer_full::{
 use tracing::{instrument, trace, warn};
 
 use crate::{abi::ForgeAbi, error::Result, utils};
-use std::{
-    collections::{BTreeMap, HashSet},
-    path::{Path, PathBuf},
-    time::Duration,
-};
 
 #[derive(Default)]
 pub struct Worker {
@@ -110,7 +111,7 @@ impl Message<UpdateContracts> for Worker {
         let contracts_with_code = stream::iter(contracts)
             .map(|(chain_id, address, code)| async move {
                 let code: Option<Bytes> = match code {
-                    Some(code) if code.len() > 0 => Some(code),
+                    Some(code) if !code.is_empty() => Some(code),
                     _ => utils::get_code(chain_id, address).await.ok(),
                 };
 
@@ -343,11 +344,12 @@ impl Worker {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
 
     use anyhow::Result;
     use tempfile::TempDir;
+
+    use super::*;
 
     #[tokio::test]
     pub async fn find_forge_tomls() -> Result<()> {

--- a/crates/rpc/src/methods/sign_message.rs
+++ b/crates/rpc/src/methods/sign_message.rs
@@ -86,7 +86,7 @@ impl<'a> SignMessage<'a> {
 #[derive(Serialize)]
 enum Data {
     Raw(String),
-    Typed(TypedData),
+    Typed(Box<TypedData>),
 }
 
 #[derive(Default)]
@@ -119,7 +119,7 @@ impl<'a> SignMessageBuilder<'a> {
     }
 
     pub fn set_typed_data(mut self, data: TypedData) -> SignMessageBuilder<'a> {
-        self.data = Some(Data::Typed(data));
+        self.data = Some(Data::Typed(Box::new(data)));
         self
     }
 

--- a/crates/types/src/events.rs
+++ b/crates/types/src/events.rs
@@ -8,7 +8,7 @@ use crate::{Address, B256};
 
 #[derive(Debug)]
 pub enum Event {
-    Tx(Tx),
+    Tx(Box<Tx>),
     ContractDeployed(ContractDeployed),
     ERC20Transfer(ERC20Transfer),
     ERC721Transfer(ERC721Transfer),
@@ -74,7 +74,7 @@ impl From<ContractDeployed> for Event {
 
 impl From<Tx> for Event {
     fn from(value: Tx) -> Self {
-        Self::Tx(value)
+        Self::Tx(Box::new(value))
     }
 }
 


### PR DESCRIPTION
The change to rust nightly caused a new lint to show up, about an enum that has a disproportionately large variant