### PR TITLE
Fix add contract network

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -37,7 +37,6 @@ impl EthUIApp {
                 ethui_networks::commands::networks_add,
                 ethui_networks::commands::networks_update,
                 ethui_networks::commands::networks_remove,
-                ethui_networks::commands::networks_is_dev,
                 ethui_networks::commands::networks_chain_id_from_provider,
                 ethui_db::commands::db_get_contracts,
                 ethui_db::commands::db_get_newer_transactions,

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -1,7 +1,6 @@
 use alloy::providers::Provider as _;
 use ethui_db::utils::{fetch_etherscan_abi, fetch_etherscan_contract_name};
 use ethui_db::Db;
-use ethui_networks::commands::networks_is_dev;
 use ethui_proxy_detect::ProxyType;
 use ethui_types::{Address, GlobalState, UINotify};
 
@@ -43,8 +42,9 @@ pub async fn add_contract(
 
     let code = provider.get_code_at(address).await?;
     let proxy = ethui_proxy_detect::detect_proxy(address, &provider).await?;
+    let network_is_dev = network.is_dev().await;
 
-    let (name, abi) = if networks_is_dev().await? {
+    let (name, abi) = if network_is_dev {
         (None, None)
     } else {
         match proxy {

--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,5 +1,6 @@
-use super::{Networks, Result};
 use ethui_types::{GlobalState, Network, NewNetworkParams};
+
+use super::{Networks, Result};
 
 #[tauri::command]
 pub async fn networks_get_current() -> Result<Network> {
@@ -43,13 +44,6 @@ pub async fn networks_remove(name: String) -> Result<()> {
     let mut networks = Networks::write().await;
     networks.remove_network(&name).await?;
     Ok(())
-}
-
-#[tauri::command]
-pub async fn networks_is_dev() -> Result<bool> {
-    let networks = Networks::read().await;
-
-    Ok(networks.get_current().is_dev().await)
 }
 
 #[tauri::command]


### PR DESCRIPTION
Why:
* The `add_contract` command was checking if the current network was a
  non-anvil chain before checking for proxy implementation, instead of
  using the network selected in the dialog

How:
* Calling `is_dev` in the Network instead of reading the value from the
  `networks_is_dev` function that checks the current network
