### PR TITLE
Fix AbiItemForm when there are no inputs

### DIFF
--- a/packages/form/src/AbiItemForm.tsx
+++ b/packages/form/src/AbiItemForm.tsx
@@ -31,7 +31,7 @@ export function AbiItemForm({
   defaultCalldata,
   defaultEther,
   onChange,
-  onSubmit = () => {},
+  onSubmit = () => { },
   submit = false,
 }: AbiItemFormProps) {
   if (!abiItem || abiItem === "raw" || abiItem === "rawCall") {

--- a/packages/form/src/AbiItemForm.tsx
+++ b/packages/form/src/AbiItemForm.tsx
@@ -31,7 +31,7 @@ export function AbiItemForm({
   defaultCalldata,
   defaultEther,
   onChange,
-  onSubmit = () => { },
+  onSubmit = () => {},
   submit = false,
 }: AbiItemFormProps) {
   if (!abiItem || abiItem === "raw" || abiItem === "rawCall") {

--- a/packages/form/src/AbiItemFormWithPreview.tsx
+++ b/packages/form/src/AbiItemFormWithPreview.tsx
@@ -46,16 +46,19 @@ export function AbiItemFormWithPreview({
 
   return (
     <div className="grid grid-cols-3 gap-2">
-      {showForm && (
-        <div className="col-span-3 md:col-span-1">
-          <AbiItemForm
-            item={abiFunction}
-            onChange={onChange}
-            defaultEther={defaultEther}
-            defaultCalldata={defaultCalldata}
-          />
-        </div>
-      )}
+      <div
+        className={clsx(
+          "col-span-3",
+          showForm ? "md:col-span-1" : "md:col-span-0",
+        )}
+      >
+        <AbiItemForm
+          item={abiFunction}
+          onChange={onChange}
+          defaultEther={defaultEther}
+          defaultCalldata={defaultCalldata}
+        />
+      </div>
       <div className={clsx("col-span-3", showForm && "md:col-span-2")}>
         {data && sender && (
           <SolidityCall


### PR DESCRIPTION
There was a bug introduced in a prior version where a function call with  no inputs would result in `data: undefined`