### PR TITLE
Show transaction status instead of successful transaction submission

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -245,8 +245,15 @@ impl Handler {
             .await;
 
         let result = sender.estimate_gas().await.finish().await?;
+        let hash = *result.tx_hash();
 
-        Ok(format!("0x{:x}", result.tx_hash()).into())
+        let receipt = result.get_receipt().await.unwrap();
+        let status = receipt.status();
+
+        Ok(json!({
+            "hash": format!("0x{:x}", hash),
+            "status": status,
+        }))
     }
 
     async fn send_call(params: serde_json::Value, ctx: Ctx) -> jsonrpc_core::Result<Bytes> {

--- a/gui/src/routes/home/_l/transactions.tsx
+++ b/gui/src/routes/home/_l/transactions.tsx
@@ -11,7 +11,7 @@ import * as tauriClipboard from "@tauri-apps/plugin-clipboard-manager";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Abi, type Address, formatEther, formatGwei } from "viem";
 
-import type { PaginatedTx, Tx } from "@ethui/types";
+import type { PaginatedTx, Tx, WriteResponse } from "@ethui/types";
 import { BlockNumber } from "@ethui/ui/components/block-number";
 import {
   Accordion,
@@ -293,7 +293,7 @@ function Details({ tx, chainId }: DetailsProps) {
 }
 
 function resend({ from, to, value, data }: Tx) {
-  invoke<string>("rpc_send_transaction", {
+  invoke<WriteResponse>("rpc_send_transaction", {
     params: { from, to, value, data },
   });
 }

--- a/gui/src/routes/home/_l/transfer/_l.eth.tsx
+++ b/gui/src/routes/home/_l/transfer/_l.eth.tsx
@@ -17,6 +17,7 @@ import { useBalances } from "#/store/useBalances";
 import { useNetworks } from "#/store/useNetworks";
 import { useWallets } from "#/store/useWallets";
 
+import type { WriteResponse } from "@ethui/types";
 import { Terminal } from "lucide-react";
 import type { Token } from "./-common";
 
@@ -113,8 +114,11 @@ function RouteComponent() {
   if (!network || !address || !currentToken) return null;
 
   const onSubmit = async (data: FieldValues) => {
-    const hash = await transferETH(address, data.to, data.value);
-    setResult(hash);
+    const result = await transferETH(address, data.to, data.value);
+
+    if (result.status && result.hash) {
+      setResult(result.hash);
+    }
   };
 
   return (
@@ -148,7 +152,7 @@ function RouteComponent() {
 }
 
 const transferETH = async (from: Address, to: Address, value: bigint) => {
-  return await invoke<`0x${string}`>("rpc_send_transaction", {
+  return await invoke<WriteResponse>("rpc_send_transaction", {
     params: {
       from,
       to,

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address, Hash } from "viem";
 
 export interface Token {
   contract: Address;
@@ -110,3 +110,8 @@ export type Affinity = { sticky: [number, number] } | "global" | "unset";
 export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E };
+
+export type WriteResponse = {
+  status: boolean;
+  hash: Hash;
+};


### PR DESCRIPTION
Why:
* #1178

How:
* Updating the `send_transaction` function to return an object with the
  transaction status instead of simply the hash so we can check if the
  transaction was reverted
