### PR TITLE
Fix clippy uninlined format warnings

### DIFF
--- a/crates/connections/src/migrations.rs
+++ b/crates/connections/src/migrations.rs
@@ -122,7 +122,7 @@ mod tests {
             }
         });
 
-        write!(tempfile, "{}", store_v0).unwrap();
+        write!(tempfile, "{store_v0}").unwrap();
 
         if let Ok(_store) = load_and_migrate(&tempfile.path().to_path_buf()) {
             let file = File::open(tempfile.path()).unwrap();
@@ -147,7 +147,7 @@ mod tests {
             }
         });
 
-        write!(tempfile, "{}", store).unwrap();
+        write!(tempfile, "{store}").unwrap();
 
         if let Ok(_store) = load_and_migrate(&tempfile.path().to_path_buf()) {
             let file = File::open(tempfile.path()).unwrap();
@@ -172,7 +172,7 @@ mod tests {
             }
         });
 
-        write!(tempfile, "{}", store_v0).unwrap();
+        write!(tempfile, "{store_v0}").unwrap();
 
         let result = load_and_migrate(&tempfile.path().to_path_buf());
 
@@ -193,7 +193,7 @@ mod tests {
             }
         });
 
-        write!(tempfile, "{}", store_v0).unwrap();
+        write!(tempfile, "{store_v0}").unwrap();
 
         if let Ok(_store) = load_and_migrate(&tempfile.path().to_path_buf()) {
             let file = File::open(tempfile.path()).unwrap();

--- a/crates/db/src/queries/chain_tip.rs
+++ b/crates/db/src/queries/chain_tip.rs
@@ -21,7 +21,7 @@ impl DbInner {
     #[instrument(skip(self), level = "trace")]
     pub async fn set_tip(&self, chain_id: u32, addr: Address, tip: u64) -> Result<()> {
         let addr = addr.to_string();
-        let tip = format!("0x{:x}", tip);
+        let tip = format!("0x{tip:x}");
 
         sqlx::query!(
             r#"INSERT OR REPLACE INTO tips (owner, chain_id, tip) 

--- a/crates/db/src/queries/contracts.rs
+++ b/crates/db/src/queries/contracts.rs
@@ -33,7 +33,7 @@ impl DbInner {
         dedup_id: i32,
         address: Address,
     ) -> Result<Option<ContractWithAbi>> {
-        let address = format!("0x{:x}", address);
+        let address = format!("0x{address:x}");
         let res = sqlx::query!(
             r#" SELECT abi, name, address
                 FROM contracts
@@ -58,7 +58,7 @@ impl DbInner {
     }
 
     pub async fn get_contract_abi(&self, chain_id: u32, address: Address) -> Result<JsonAbi> {
-        let address = format!("0x{:x}", address);
+        let address = format!("0x{address:x}");
 
         let res = sqlx::query!(
             r#" SELECT abi
@@ -86,9 +86,9 @@ impl DbInner {
         name: Option<String>,
         proxy_for: Option<Address>,
     ) -> Result<()> {
-        let address = format!("0x{:x}", address);
-        let proxy_for = proxy_for.map(|p| format!("0x{:x}", p));
-        let code = code.map(|c| format!("0x{:x}", c));
+        let address = format!("0x{address:x}");
+        let proxy_for = proxy_for.map(|p| format!("0x{p:x}"));
+        let code = code.map(|c| format!("0x{c:x}"));
         let chain_id = dedup_chain_id.chain_id();
         let dedup_id = dedup_chain_id.dedup_id();
 
@@ -168,7 +168,7 @@ impl DbInner {
         dedup_id: i32,
         address: Address,
     ) -> Result<()> {
-        let address = format!("0x{:x}", address);
+        let address = format!("0x{address:x}");
 
         sqlx::query!(
             r#"DELETE FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?"#,
@@ -188,7 +188,7 @@ impl DbInner {
         dedup_id: i32,
         address: Address,
     ) -> Option<Address> {
-        let address = format!("0x{:x}", address);
+        let address = format!("0x{address:x}");
 
         let result = sqlx::query_scalar!(
             r#"SELECT proxied_by FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?"#,

--- a/crates/db/src/queries/erc1155.rs
+++ b/crates/db/src/queries/erc1155.rs
@@ -16,9 +16,9 @@ impl DbInner {
         let row = sqlx::query(
             r#"SELECT balance FROM erc1155_tokens WHERE chain_id = ? AND contract = ? AND owner = ? AND token_id = ?"#)
             .bind(chain_id)
-            .bind(format!("0x{:x}", contract))
-            .bind(format!("0x{:x}", owner))
-            .bind(format!("0x{:x}", token_id))
+            .bind(format!("0x{contract:x}"))
+            .bind(format!("0x{owner:x}"))
+            .bind(format!("0x{token_id:x}"))
             .fetch_one(self.pool())
             .await?;
         let balance: String = row.get("balance");
@@ -34,8 +34,8 @@ impl DbInner {
         let row = sqlx::query(
             r#"SELECT balance FROM erc1155_tokens WHERE chain_id = ? AND contract = ? AND token_id = ?"#)
             .bind(chain_id)
-            .bind(format!("0x{:x}", contract))
-            .bind(format!("0x{:x}", token_id))
+            .bind(format!("0x{contract:x}"))
+            .bind(format!("0x{token_id:x}"))
             .fetch_one(self.pool())
             .await?;
         Ok(row.get("uri"))
@@ -50,8 +50,8 @@ impl DbInner {
         let row = sqlx::query(
             r#"SELECT balance FROM erc1155_tokens WHERE chain_id = ? AND contract = ? AND token_id = ?"#)
             .bind(chain_id)
-            .bind(format!("0x{:x}", contract))
-            .bind(format!("0x{:x}", token_id))
+            .bind(format!("0x{contract:x}"))
+            .bind(format!("0x{token_id:x}"))
             .fetch_one(self.pool())
             .await?;
         Ok(row.get("metadata"))
@@ -69,10 +69,10 @@ impl DbInner {
             r#"INSERT OR REPLACE INTO balances (contract, chain_id, token_id, owner, balance)
                 VALUES (?,?,?,?) "#,
         )
-        .bind(format!("0x{:x}", contract))
+        .bind(format!("0x{contract:x}"))
         .bind(chain_id)
-        .bind(format!("0x{:x}", token_id))
-        .bind(format!("0x{:x}", owner))
+        .bind(format!("0x{token_id:x}"))
+        .bind(format!("0x{owner:x}"))
         .bind(balance.to_string())
         .execute(self.pool())
         .await?;
@@ -115,9 +115,9 @@ impl DbInner {
                 WHERE chain_id = ? AND contract = ? AND token_id = ? AND owner = ?"#,
             )
             .bind(chain_id)
-            .bind(format!("0x{:x}", contract))
-            .bind(format!("0x{:x}", token_id))
-            .bind(format!("0x{:x}", from))
+            .bind(format!("0x{contract:x}"))
+            .bind(format!("0x{token_id:x}"))
+            .bind(format!("0x{from:x}"))
             .execute(self.pool())
             .await?;
         } else {
@@ -158,10 +158,10 @@ impl DbInner {
         r#" INSERT OR REPLACE INTO erc1155_tokens (contract, chain_id, token_id, owner, balance, uri, metadata)
                 VALUES (?,?,?,?,?,?,?) "#,
         )
-        .bind(format!("0x{:x}", contract))
+        .bind(format!("0x{contract:x}"))
         .bind(chain_id)
-        .bind(format!("0x{:x}", token_id))
-        .bind(format!("0x{:x}", owner))
+        .bind(format!("0x{token_id:x}"))
+        .bind(format!("0x{owner:x}"))
         .bind(balance.to_string())
         .bind(uri)
         .bind(metadata)
@@ -201,7 +201,7 @@ impl DbInner {
             r#" INSERT OR REPLACE INTO erc1155_collections (contract, chain_id, name, symbol)
                       VALUES (?,?,?,?) "#,
         )
-        .bind(format!("0x{:x}", contract))
+        .bind(format!("0x{contract:x}"))
         .bind(chain_id)
         .bind(name)
         .bind(symbol)
@@ -224,7 +224,7 @@ impl DbInner {
                 WHERE erc1155_tokens.chain_id = ? AND erc1155_tokens.owner = ?"#,
       )
       .bind(chain_id)
-      .bind(format!("0x{:x}", owner))
+      .bind(format!("0x{owner:x}"))
       .map(|row| row.try_into().unwrap())
       .fetch_all(self.pool())
       .await?;

--- a/crates/db/src/queries/erc721.rs
+++ b/crates/db/src/queries/erc721.rs
@@ -20,8 +20,8 @@ impl DbInner {
                 r#" DELETE FROM erc721_tokens WHERE chain_id = ? AND contract = ? AND token_id = ? "#,
             )
             .bind(chain_id)
-            .bind(format!("0x{:x}", contract))
-            .bind(format!("0x{:x}", token_id))
+            .bind(format!("0x{contract:x}"))
+            .bind(format!("0x{token_id:x}"))
             .execute(self.pool()).await?;
         } else {
             // minting or transfer
@@ -29,10 +29,10 @@ impl DbInner {
                 r#" INSERT OR REPLACE INTO erc721_tokens (contract, chain_id, token_id, owner)
                         VALUES (?,?,?,?)"#,
             )
-            .bind(format!("0x{:x}", contract))
+            .bind(format!("0x{contract:x}"))
             .bind(chain_id)
-            .bind(format!("0x{:x}", token_id))
-            .bind(format!("0x{:x}", to))
+            .bind(format!("0x{token_id:x}"))
+            .bind(format!("0x{to:x}"))
             .execute(self.pool())
             .await?;
         }
@@ -68,10 +68,10 @@ impl DbInner {
         r#" INSERT OR REPLACE INTO erc721_tokens (contract, chain_id, token_id, owner, uri, metadata)
                         VALUES (?,?,?,?,?,?) "#,
     )
-    .bind(format!("0x{:x}", address))
+    .bind(format!("0x{address:x}"))
     .bind(chain_id)
-    .bind(format!("0x{:x}", token_id))
-    .bind(format!("0x{:x}", owner))
+    .bind(format!("0x{token_id:x}"))
+    .bind(format!("0x{owner:x}"))
     .bind(uri)
     .bind(metadata)
             .execute(self.pool()).await?;
@@ -109,7 +109,7 @@ impl DbInner {
             r#" INSERT OR REPLACE INTO erc721_collections (contract, chain_id, name, symbol)
                       VALUES (?,?,?,?) "#,
         )
-        .bind(format!("0x{:x}", address))
+        .bind(format!("0x{address:x}"))
         .bind(chain_id)
         .bind(name)
         .bind(symbol)
@@ -132,7 +132,7 @@ impl DbInner {
       WHERE erc721_tokens.chain_id = ? AND erc721_tokens.owner = ?"#,
       )
       .bind(chain_id)
-      .bind(format!("0x{:x}", owner))
+      .bind(format!("0x{owner:x}"))
       .map(|row| row.try_into().unwrap())
       .fetch_all(self.pool())
       .await?;

--- a/crates/db/src/queries/native_balance.rs
+++ b/crates/db/src/queries/native_balance.rs
@@ -10,7 +10,7 @@ impl DbInner {
         address: Address,
     ) -> Result<()> {
         let balance = balance.to_string();
-        let address = format!("0x{:x}", address);
+        let address = format!("0x{address:x}");
 
         sqlx::query!(
             r#" INSERT OR REPLACE INTO native_balances (balance, chain_id, owner)

--- a/crates/db/src/queries/transactions.rs
+++ b/crates/db/src/queries/transactions.rs
@@ -22,7 +22,7 @@ impl DbInner {
                 .join("/")
         });
         let from = format!("0x{:x}", tx.from);
-        let to = tx.to.map(|a| format!("0x{:x}", a));
+        let to = tx.to.map(|a| format!("0x{a:x}"));
         let block_number = tx.block_number.map(|b| b as i64);
         let position = tx.position.unwrap_or(0) as u32;
         let value = tx.value.map(|v| v.to_string());
@@ -212,8 +212,8 @@ impl DbInner {
     }
 
     pub async fn get_call_count(&self, chain_id: u32, from: Address, to: Address) -> Result<u32> {
-        let from = format!("0x{:x}", from);
-        let to = format!("0x{:x}", to);
+        let from = format!("0x{from:x}");
+        let to = format!("0x{to:x}");
 
         let row = sqlx::query!(
             r#"SELECT count(*) as count FROM transactions WHERE chain_id = ? AND from_address = ? AND to_address = ?"#,

--- a/crates/ws/src/server.rs
+++ b/crates/ws/src/server.rs
@@ -18,7 +18,7 @@ pub use crate::error::{WsError, WsResult};
 use crate::peers::{Peer, Peers};
 
 pub(crate) async fn server_loop(port: u16) {
-    let addr = format!("127.0.0.1:{}", port);
+    let addr = format!("127.0.0.1:{port}");
     let listener = TcpListener::bind(&addr).await.expect("Can't listen to");
 
     tracing::debug!("WS server listening on: {}", addr);


### PR DESCRIPTION
Why:
* The latest nightly release includes a new rule
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

How:
* Inlining all variables in `format!` macro calls
