### PR TITLE
Fixes proxy contract display and interaction

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -45,6 +45,7 @@ impl EthUIApp {
                 ethui_db::commands::db_get_older_transactions,
                 ethui_db::commands::db_get_transaction_by_hash,
                 ethui_db::commands::db_get_contract_abi,
+                ethui_db::commands::db_get_contract_impl_abi,
                 ethui_db::commands::db_get_erc20_metadata,
                 ethui_db::commands::db_get_erc20_balances,
                 ethui_db::commands::db_get_erc20_blacklist,

--- a/crates/db/src/commands.rs
+++ b/crates/db/src/commands.rs
@@ -106,6 +106,15 @@ pub async fn db_get_contract_abi(
 }
 
 #[tauri::command]
+pub async fn db_get_contract_impl_abi(
+    chain_id: u32,
+    address: Address,
+    db: tauri::State<'_, Db>,
+) -> Result<JsonAbi> {
+    db.get_contract_impl_abi(chain_id, address).await
+}
+
+#[tauri::command]
 pub async fn db_get_erc721_tokens(
     chain_id: u32,
     owner: Address,

--- a/gui/src/components/AddressView.tsx
+++ b/gui/src/components/AddressView.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
 } from "@ethui/ui/components/shadcn/dialog";
 import { Link } from "@tanstack/react-router";
+import clsx from "clsx";
 import { useInvoke } from "#/hooks/useInvoke";
 import { useNetworks } from "#/store/useNetworks";
 import { truncateHex } from "#/utils";
@@ -33,12 +34,14 @@ interface Props {
   copyIcon?: boolean;
   contextMenu?: boolean;
   icon?: boolean;
+  noTextStyle?: boolean;
 }
 
 export function AddressView({
   address: addr,
   contextMenu = true,
   icon = false,
+  noTextStyle = false,
 }: Props) {
   const network = useNetworks((s) => s.current);
   const address = getAddress(addr);
@@ -52,7 +55,12 @@ export function AddressView({
   const text = alias ? alias : truncateHex(address);
   const content = (
     <ClickToCopy text={address}>
-      <div className="flex items-center gap-x-1 font-mono text-base">
+      <div
+        className={clsx(
+          "flex items-center gap-x-1 font-mono",
+          noTextStyle ? "" : "text-base",
+        )}
+      >
         {icon && (
           <IconAddress
             chainId={network.dedup_chain_id.chain_id}

--- a/gui/src/components/ContractCallForm.tsx
+++ b/gui/src/components/ContractCallForm.tsx
@@ -47,7 +47,7 @@ type GroupedOptions = Record<Group, Option[]>;
 
 export function ContractCallForm({ chainId, address }: Props) {
   const [filter, setFilter] = useState("");
-  const { data: abi } = useInvoke<Abi>("db_get_contract_abi", {
+  const { data: abi } = useInvoke<Abi>("db_get_contract_impl_abi", {
     address,
     chainId,
   });

--- a/gui/src/routes/home/_l/contracts/_l/index.tsx
+++ b/gui/src/routes/home/_l/contracts/_l/index.tsx
@@ -1,6 +1,6 @@
 import { Link, createFileRoute } from "@tanstack/react-router";
 import debounce from "lodash-es/debounce";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useShallow } from "zustand/shallow";
 
 import { Badge } from "@ethui/ui/components/shadcn/badge";
@@ -9,7 +9,7 @@ import { Input } from "@ethui/ui/components/shadcn/input";
 import { MoveRight, Plus, Trash2 } from "lucide-react";
 import type { Address } from "viem";
 import { AddressView } from "#/components/AddressView";
-import { useContracts } from "#/store/useContracts";
+import { type OrganizedContract, useContracts } from "#/store/useContracts";
 
 export const Route = createFileRoute("/home/_l/contracts/_l/")({
   component: Contracts,
@@ -26,6 +26,7 @@ function Contracts() {
 
   const removeContract = useContracts((s) => s.removeContract);
 
+  console.log(contracts);
   const startRemoveContract = (address: Address) => {
     setPendingDeleteContract(address);
   };
@@ -36,29 +37,14 @@ function Contracts() {
 
       <div className="flex flex-col gap-2 pt-2">
         {Array.from(contracts || []).map(
-          ({ address, name, chainId, proxyName }) => (
+          ({ address, name, chainId, proxyChain }) => (
             <div
               key={address}
               className="flex flex-wrap hover:bg-accent xl:flex-nowrap"
             >
-              <div className="grow pr-32">
-                <Link
-                  to="/home/contracts/$chainId/$address"
-                  params={{ address: address, chainId: chainId }}
-                  className="flex whitespace-nowrap p-4 align-baseline"
-                >
-                  <div className="flex w-full items-center gap-2">
-                    <AddressView address={address} />
-                    {proxyName && (
-                      <>
-                        <Badge variant="secondary">{proxyName}</Badge>
-                        <MoveRight strokeWidth={1} size={16} />
-                      </>
-                    )}
-                    {name && <Badge variant="secondary">{name}</Badge>}
-                  </div>
-                </Link>
-              </div>
+              <ContractHeader
+                contract={{ address, name, chainId, proxyChain }}
+              />
               {(!pendingDeleteContract ||
                 pendingDeleteContract !== address) && (
                 <div className="flex items-center">
@@ -115,5 +101,40 @@ function Filter({ onChange }: { onChange: (f: string) => void }) {
         className="h-10"
       />
     </form>
+  );
+}
+
+function ContractHeader({ contract }: { contract: OrganizedContract }) {
+  const { address, name, chainId, proxyChain } = contract;
+
+  return (
+    <div className="grow pr-32">
+      <Link
+        to="/home/contracts/$chainId/$address"
+        params={{ address: address, chainId: chainId }}
+        className="flex whitespace-nowrap p-4 align-baseline"
+      >
+        <div className="flex w-full items-center gap-2">
+          <AddressView address={address} />
+
+          <div className="flex items-center">
+            {name && (
+              <Badge key={address} variant="secondary">
+                {name}
+              </Badge>
+            )}
+
+            {proxyChain.map(({ address, name }) => (
+              <Fragment key={address}>
+                <MoveRight strokeWidth={1} size={16} />
+                <Badge key={address} variant="secondary">
+                  {name ? name : <AddressView address={address} noTextStyle />}
+                </Badge>
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      </Link>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #1236 

The logic for nesting implementations and proxy contracts in the UI was relying on the db table orderling (proxies needed to come before their impl). This assumption was broken when inserting contracts via the manual flow

Additionally, when interacting with a proxy contract, we were actually using the impl as the target contract, when we should be using the proxy contract as target but the impl's ABI.

The new logic is also more resilient when it comes to proxies of proxies (not fully tested yet)