### PR TITLE
Add tauri command to fetch forge ABIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tauri",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -53,6 +53,7 @@ impl EthUIApp {
                 ethui_db::commands::db_clear_erc20_blacklist,
                 ethui_db::commands::db_get_native_balance,
                 ethui_db::commands::db_get_erc721_tokens,
+                ethui_forge::commands::fetch_forge_abis,
                 ethui_ws::commands::ws_peers_by_domain,
                 ethui_ws::commands::ws_peer_count,
                 ethui_wallets::commands::wallets_get_all,

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -19,6 +19,7 @@ ethui-db.workspace = true
 alloy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tauri.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/forge/src/abi.rs
+++ b/crates/forge/src/abi.rs
@@ -1,8 +1,10 @@
 use std::{ffi::OsStr, fs::File, io::BufReader, path::PathBuf, str::FromStr as _};
 
 use alloy::primitives::Bytes;
+use kameo::Reply;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Reply, Serialize, Deserialize)]
 pub struct ForgeAbi {
     pub path: PathBuf,
     pub project: String,
@@ -10,6 +12,7 @@ pub struct ForgeAbi {
     pub name: String,
     pub code: Bytes,
     pub abi: serde_json::Value,
+    pub method_identifiers: serde_json::Value,
 }
 
 impl TryFrom<PathBuf> for ForgeAbi {
@@ -54,6 +57,7 @@ impl TryFrom<PathBuf> for ForgeAbi {
         };
 
         let file = File::open(path.clone()).unwrap();
+
         let json: serde_json::Value =
             serde_json::from_reader(BufReader::new(file)).map_err(|_| ())?;
 
@@ -62,6 +66,8 @@ impl TryFrom<PathBuf> for ForgeAbi {
             Some(b) => Bytes::from_str(b).map_err(|_| ())?,
             _ => return Err(()),
         };
+
+        let method_identifiers = json["methodIdentifiers"].clone();
 
         if abi.is_null() {
             return Err(());
@@ -73,6 +79,7 @@ impl TryFrom<PathBuf> for ForgeAbi {
             solidity_file,
             name,
             abi,
+            method_identifiers,
             code,
         })
     }

--- a/crates/forge/src/actor.rs
+++ b/crates/forge/src/actor.rs
@@ -151,6 +151,20 @@ impl Message<UpdateContracts> for Worker {
     }
 }
 
+pub struct FetchAbis;
+
+impl Message<FetchAbis> for Worker {
+    type Reply = Vec<ForgeAbi>;
+
+    async fn handle(
+        &mut self,
+        _msg: FetchAbis,
+        _ctx: kameo::message::Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.abis_by_path.clone().into_values().collect()
+    }
+}
+
 impl Actor for Worker {
     type Mailbox = BoundedMailbox<Self>;
 

--- a/crates/forge/src/commands.rs
+++ b/crates/forge/src/commands.rs
@@ -1,0 +1,14 @@
+use kameo::actor::ActorRef;
+
+use crate::{
+    abi::ForgeAbi,
+    actor::{FetchAbis, Worker},
+    error::{Error, Result},
+};
+
+#[tauri::command]
+pub async fn fetch_forge_abis() -> Result<Vec<ForgeAbi>> {
+    let actor = ActorRef::<Worker>::lookup("forge_actor")?.ok_or(Error::ActorNotFound)?;
+
+    Ok(actor.ask(FetchAbis).await?)
+}

--- a/crates/forge/src/error.rs
+++ b/crates/forge/src/error.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use alloy::transports::{RpcError, TransportErrorKind};
 
-use crate::actor;
+use crate::actor::{self, FetchAbis};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -46,6 +46,15 @@ pub enum Error {
 
     #[error(transparent)]
     ActorSend(#[from] kameo::error::SendError<actor::Msg>),
+
+    #[error("Actor lookup error")]
+    ActorNotFound,
+
+    #[error(transparent)]
+    RegistryError(#[from] kameo::error::RegistryError),
+
+    #[error(transparent)]
+    ActorCall(#[from] kameo::error::SendError<FetchAbis>),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -7,6 +7,7 @@ use crate::actor::{Msg, Worker};
 
 pub async fn init() -> crate::Result<()> {
     let handle = kameo::spawn(Worker::default());
+    handle.register("forge_actor").unwrap();
     let settings = Settings::read().await;
 
     if let Some(ref path) = settings.inner.abi_watch_path {

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -1,5 +1,6 @@
 mod abi;
 mod actor;
+pub mod commands;
 mod error;
 mod init;
 mod utils;


### PR DESCRIPTION
Why:
* We need a way to get the ABIs we parsed from Forge to be later used in
  the UI

How:
* Adding a `fetch_forge_abis` tauri command that asks the Kameo Forge
  actor to send the values of the `abis_by_path`
* Updating the `ForgeAbi` struct to be deserealizable and to include
  `method_identifiers`
