### PR TITLE
blockExplorerUrls should be optional

### DIFF
--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -66,7 +66,7 @@ pub struct Params {
     pub chain_name: String,
     pub rpc_urls: Vec<Url>,
     pub native_currency: Currency,
-    pub block_explorer_urls: Vec<Url>,
+    pub block_explorer_urls: Option<Vec<Url>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -108,7 +108,11 @@ impl TryFrom<Params> for NewNetworkParams {
             name: params.chain_name,
             // Using 0 for dedup_id since at this time no duplicate chain_id is allowed
             dedup_chain_id: (params.chain_id.try_into().unwrap(), 0).into(),
-            explorer_url: params.block_explorer_urls.first().map(|u| u.to_string()),
+            explorer_url: params
+                .block_explorer_urls
+                .unwrap_or_default()
+                .first()
+                .map(|u| u.to_string()),
             http_url: params
                 .rpc_urls
                 .iter()

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -119,7 +119,11 @@ impl ChainUpdateBuilder {
         let new_network_params = NewNetworkParams {
             dedup_chain_id: (params.chain_id.try_into().unwrap(), 0).into(),
             name: chain_name.clone(),
-            explorer_url: params.block_explorer_urls.first().map(|u| u.to_string()),
+            explorer_url: params
+                .block_explorer_urls
+                .unwrap_or_default()
+                .first()
+                .map(|u| u.to_string()),
             http_url: params
                 .rpc_urls
                 .iter()


### PR DESCRIPTION
When adding new chains, if `blockExplorerUrls: null`, we should treat in the same way as `blockExplorerUrls: []`.
The previous code would just fail to deserialize the field and error out on the request