### PR TITLE
Fix onboarding finish flow

### DIFF
--- a/crates/settings/src/onboarding.rs
+++ b/crates/settings/src/onboarding.rs
@@ -38,6 +38,7 @@ impl Onboarding {
         self.steps.insert(OnboardingStep::Extension, true);
         self.steps.insert(OnboardingStep::Wallet, true);
         self.steps.insert(OnboardingStep::Alchemy, true);
+        self.steps.insert(OnboardingStep::Etherscan, true);
         self.hidden = true;
     }
 


### PR DESCRIPTION
Why:
* The step for the `OnboardingStep::Etherscan` was missing from the
  function that sets the onboarding to finished, causing the
  `is_all_finished` function to wrongly assume all the onboarding steps
  were completed

How:
* Adding the missing step to `steps`
