### PR TITLE
Trace viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1119,6 +1119,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.0",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1159,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2722,6 +2763,18 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+dependencies = [
+ "bitflags 2.8.0",
+ "block2 0.6.1",
+ "libc",
+ "objc2 0.6.1",
+]
+
+[[package]]
+name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
@@ -2899,12 +2952,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -3016,6 +3096,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-os",
  "tauri-plugin-shell",
  "thiserror 2.0.12",
@@ -3399,6 +3481,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,7 +3862,7 @@ dependencies = [
  "foundry-compilers-core",
  "futures-util",
  "home",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "path-slash",
  "rayon",
  "semver 1.0.23",
@@ -4201,6 +4293,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -5938,6 +6043,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6139,7 +6257,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -6275,7 +6393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.8.0",
- "dispatch2",
+ "dispatch2 0.3.0",
  "objc2 0.6.1",
 ]
 
@@ -6286,7 +6404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.8.0",
- "dispatch2",
+ "dispatch2 0.3.0",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -6482,6 +6600,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_info"
@@ -7693,6 +7821,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d"
+dependencies = [
+ "ashpd",
+ "block2 0.6.1",
+ "dispatch2 0.2.0",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.1",
+ "objc2-app-kit 0.3.1",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8623,7 +8776,7 @@ dependencies = [
  "derive_builder",
  "derive_more 2.0.1",
  "dunce",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "itoa 1.0.11",
  "lasso",
  "match_cfg",
@@ -8659,7 +8812,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.8.0",
  "bumpalo",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -9394,6 +9547,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcaf6e5d6062423a0f711a23c2a573ccba222b6a16a9322d8499928f27e41376"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.12",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88371e340ad2f07409a3b68294abe73f20bc9c1bc1b631a31dc37a3d0161f682"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.12",
+ "toml",
+ "url",
+ "uuid 1.11.0",
+]
+
+[[package]]
 name = "tauri-plugin-os"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10106,6 +10300,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "uint"
@@ -11424,6 +11629,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2522b82023923eecb0b366da727ec883ace092e7887b61d3da5139f26b44da58"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.7.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d2e12843c75108c00c618c2e8ef9675b50b6ec095b36dc965f2e5aed463c15"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11556,4 +11816,46 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557e89d54880377a507c94cd5452f20e35d14325faf9d2958ebeadce0966c1b2"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757779842a0d242061d24c28be589ce392e45350dfb9186dfd7a042a2e19870c"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.87",
+ "winnow 0.7.3",
 ]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -47,6 +47,8 @@ tauri-plugin-clipboard-manager = "2.2"
 tauri-plugin-shell = "2"
 ethui-proxy-detect.workspace = true
 kameo.workspace = true
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 
 [build-dependencies]
 tauri-build = { version = "2.2", default-features = false, features = [] }

--- a/bin/capabilities/main.json
+++ b/bin/capabilities/main.json
@@ -13,6 +13,8 @@
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-text",
     "shell:allow-open",
-    "shell:default"
+    "shell:default",
+    "dialog:default",
+    "fs:default"
   ]
 }

--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -79,6 +79,8 @@ impl EthUIApp {
                 ethui_simulator::commands::simulator_run,
                 ethui_simulator::commands::simulator_get_call_count,
             ])
+            .plugin(tauri_plugin_dialog::init())
+            .plugin(tauri_plugin_fs::init())
             .plugin(tauri_plugin_os::init())
             .plugin(tauri_plugin_clipboard_manager::init())
             .plugin(tauri_plugin_shell::init())

--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -21,6 +21,7 @@ import {
 import { Link, useLocation } from "@tanstack/react-router";
 import { platform } from "@tauri-apps/plugin-os";
 import {
+  Braces,
   ChevronDown,
   ChevronRight,
   CircleUser,
@@ -183,6 +184,11 @@ const items = [
     title: "Connections",
     url: "/home/connections",
     icon: <Wifi />,
+  },
+  {
+    title: "Traces",
+    url: "/home/traces",
+    icon: <Braces />,
   },
 ];
 

--- a/gui/src/components/TraceViewer.tsx
+++ b/gui/src/components/TraceViewer.tsx
@@ -1,0 +1,133 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@ethui/ui/components/shadcn/collapsible";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@ethui/ui/lib/utils";
+import type { TreeNode } from "../lib/convertForgeTestTrace";
+
+interface TreeNodeProps {
+  node: TreeNode;
+  level: number;
+  className?: string;
+  labels: Record<string, string>;
+}
+
+interface TraceViewProps {
+  nodes: TreeNode[];
+  labels: Record<string, string>;
+  className?: string;
+}
+
+export function TraceView({ nodes, className, labels }: TraceViewProps) {
+  return (
+    <div className={cn("w-full", className)}>
+      {nodes.map((node) => (
+        <TraceNode key={node.id} node={node} level={0} labels={labels} />
+      ))}
+    </div>
+  );
+}
+
+function TraceNode({ node, level, className, labels }: TreeNodeProps) {
+  const [selected, setSelected] = useState(false);
+
+  const handleSelect = () => {
+    setSelected(!selected);
+  };
+
+  const hasChildren = node.children && node.children.length > 0;
+
+  function label(
+    node: TreeNode,
+    labels: Record<string, string>,
+  ): React.JSX.Element {
+    if (node?.metadata?.details?.error) {
+      return (
+        <span className="text-red-800">{`${labels[node?.metadata?.traceInfo?.trace?.address]}::${node?.metadata.details.name} ${node.metadata.details.error.args[0]}`}</span>
+      );
+    }
+
+    if (node?.metadata?.traceInfo?.trace?.kind === "CREATE") {
+      return (
+        <span className="text-solidity-value">{`new ${labels[node?.metadata?.traceInfo?.trace?.address]}()`}</span>
+      );
+    }
+
+    if (
+      node?.metadata?.traceInfo?.trace?.kind === "CALL" ||
+      node?.metadata?.traceInfo?.trace?.kind === "STATICCALL"
+    ) {
+      return (
+        <span className="text-solidity-callname">{`${labels[node?.metadata?.traceInfo?.trace?.address]}::${node?.metadata?.details?.name}()`}</span>
+      );
+    }
+
+    if (node?.metadata?.details) {
+      return <span>{node?.metadata?.details?.name}</span>;
+    }
+
+    return <span>{node?.label}</span>;
+  }
+
+  return (
+    <div className={className}>
+      <Collapsible defaultOpen={false}>
+        <CollapsibleTrigger
+          className={cn(
+            "flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50",
+            node.metadata.status && node.metadata.status === "Success"
+              ? "text-emerald-700"
+              : "text-white-500",
+          )}
+          style={{ paddingLeft: `${level * 12}px` }}
+          onClick={handleSelect}
+        >
+          {hasChildren ? (
+            <ChevronRight className="mr-1 h-4 w-4 shrink-0 ui-open:rotate-90 transition-transform" />
+          ) : (
+            <div className="w-5" />
+          )}
+
+          <div className="shrink-0 justify-items-start">
+            <p
+              className={cn(
+                "font-medium text-sm",
+                node.metadata.status === "Failure"
+                  ? "text-red-400"
+                  : "text-white-500",
+              )}
+            >
+              {label(node, labels)}
+              <span className={"text-blue-300"}>
+                {node.metadata.nodeType === "rootNode" &&
+                  ` ${node.metadata.duration}`}
+              </span>
+            </p>
+            <p className="text-left font-medium text-emerald-700 text-sm">
+              {node.metadata.details && node.metadata.details.returns.length > 0
+                ? ` [return] ${node.metadata.details.returns[0].varvalue}`
+                : null}
+            </p>
+          </div>
+        </CollapsibleTrigger>
+
+        {hasChildren && (
+          <CollapsibleContent>
+            {node.children?.map((child) => (
+              <TraceNode
+                key={child.id}
+                node={child}
+                level={level + 1}
+                labels={labels}
+              />
+            ))}
+          </CollapsibleContent>
+        )}
+      </Collapsible>
+    </div>
+  );
+}

--- a/gui/src/lib/dataParser.ts
+++ b/gui/src/lib/dataParser.ts
@@ -24,7 +24,7 @@ type TraceLog = {
   };
 };
 
-export type SolidityVariable = {
+type SolidityVariable = {
   vartype: string;
   varname: string;
   varvalue: string;

--- a/gui/src/routeTree.gen.ts
+++ b/gui/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as rootRoute } from './routes/__root'
 import { Route as HomeLImport } from './routes/home/_l'
 import { Route as DialogLImport } from './routes/dialog/_l'
 import { Route as HomeLTransactionsImport } from './routes/home/_l/transactions'
+import { Route as HomeLTracesImport } from './routes/home/_l/traces'
 import { Route as HomeLOnboardingImport } from './routes/home/_l/onboarding'
 import { Route as HomeLConnectionsImport } from './routes/home/_l/connections'
 import { Route as HomeLAccountImport } from './routes/home/_l/account'
@@ -106,6 +107,12 @@ const HomeLContractsRoute = HomeLContractsImport.update({
 const HomeLTransactionsRoute = HomeLTransactionsImport.update({
   id: '/transactions',
   path: '/transactions',
+  getParentRoute: () => HomeLRoute,
+} as any)
+
+const HomeLTracesRoute = HomeLTracesImport.update({
+  id: '/traces',
+  path: '/traces',
   getParentRoute: () => HomeLRoute,
 } as any)
 
@@ -354,6 +361,13 @@ declare module '@tanstack/react-router' {
       path: '/onboarding'
       fullPath: '/home/onboarding'
       preLoaderRoute: typeof HomeLOnboardingImport
+      parentRoute: typeof HomeLImport
+    }
+    '/home/_l/traces': {
+      id: '/home/_l/traces'
+      path: '/traces'
+      fullPath: '/home/traces'
+      preLoaderRoute: typeof HomeLTracesImport
       parentRoute: typeof HomeLImport
     }
     '/home/_l/transactions': {
@@ -781,6 +795,7 @@ interface HomeLRouteChildren {
   HomeLAccountRoute: typeof HomeLAccountRoute
   HomeLConnectionsRoute: typeof HomeLConnectionsRoute
   HomeLOnboardingRoute: typeof HomeLOnboardingRoute
+  HomeLTracesRoute: typeof HomeLTracesRoute
   HomeLTransactionsRoute: typeof HomeLTransactionsRoute
   HomeLContractsRoute: typeof HomeLContractsRouteWithChildren
   HomeLSettingsRoute: typeof HomeLSettingsRouteWithChildren
@@ -791,6 +806,7 @@ const HomeLRouteChildren: HomeLRouteChildren = {
   HomeLAccountRoute: HomeLAccountRoute,
   HomeLConnectionsRoute: HomeLConnectionsRoute,
   HomeLOnboardingRoute: HomeLOnboardingRoute,
+  HomeLTracesRoute: HomeLTracesRoute,
   HomeLTransactionsRoute: HomeLTransactionsRoute,
   HomeLContractsRoute: HomeLContractsRouteWithChildren,
   HomeLSettingsRoute: HomeLSettingsRouteWithChildren,
@@ -815,6 +831,7 @@ export interface FileRoutesByFullPath {
   '/home/account': typeof HomeLAccountRoute
   '/home/connections': typeof HomeLConnectionsRoute
   '/home/onboarding': typeof HomeLOnboardingRoute
+  '/home/traces': typeof HomeLTracesRoute
   '/home/transactions': typeof HomeLTransactionsRoute
   '/dialog/chain-add/$id': typeof DialogLChainAddIdRoute
   '/dialog/chain-switch/$id': typeof DialogLChainSwitchIdRoute
@@ -851,6 +868,7 @@ export interface FileRoutesByTo {
   '/home/account': typeof HomeLAccountRoute
   '/home/connections': typeof HomeLConnectionsRoute
   '/home/onboarding': typeof HomeLOnboardingRoute
+  '/home/traces': typeof HomeLTracesRoute
   '/home/transactions': typeof HomeLTransactionsRoute
   '/dialog/chain-add/$id': typeof DialogLChainAddIdRoute
   '/dialog/chain-switch/$id': typeof DialogLChainSwitchIdRoute
@@ -887,6 +905,7 @@ export interface FileRoutesById {
   '/home/_l/account': typeof HomeLAccountRoute
   '/home/_l/connections': typeof HomeLConnectionsRoute
   '/home/_l/onboarding': typeof HomeLOnboardingRoute
+  '/home/_l/traces': typeof HomeLTracesRoute
   '/home/_l/transactions': typeof HomeLTransactionsRoute
   '/dialog/_l/chain-add/$id': typeof DialogLChainAddIdRoute
   '/dialog/_l/chain-switch/$id': typeof DialogLChainSwitchIdRoute
@@ -930,6 +949,7 @@ export interface FileRouteTypes {
     | '/home/account'
     | '/home/connections'
     | '/home/onboarding'
+    | '/home/traces'
     | '/home/transactions'
     | '/dialog/chain-add/$id'
     | '/dialog/chain-switch/$id'
@@ -965,6 +985,7 @@ export interface FileRouteTypes {
     | '/home/account'
     | '/home/connections'
     | '/home/onboarding'
+    | '/home/traces'
     | '/home/transactions'
     | '/dialog/chain-add/$id'
     | '/dialog/chain-switch/$id'
@@ -999,6 +1020,7 @@ export interface FileRouteTypes {
     | '/home/_l/account'
     | '/home/_l/connections'
     | '/home/_l/onboarding'
+    | '/home/_l/traces'
     | '/home/_l/transactions'
     | '/dialog/_l/chain-add/$id'
     | '/dialog/_l/chain-switch/$id'
@@ -1092,6 +1114,7 @@ export const routeTree = rootRoute
         "/home/_l/account",
         "/home/_l/connections",
         "/home/_l/onboarding",
+        "/home/_l/traces",
         "/home/_l/transactions",
         "/home/_l/contracts",
         "/home/_l/settings",
@@ -1108,6 +1131,10 @@ export const routeTree = rootRoute
     },
     "/home/_l/onboarding": {
       "filePath": "home/_l/onboarding.tsx",
+      "parent": "/home/_l"
+    },
+    "/home/_l/traces": {
+      "filePath": "home/_l/traces.tsx",
       "parent": "/home/_l"
     },
     "/home/_l/transactions": {

--- a/gui/src/routes/home/_l/traces.tsx
+++ b/gui/src/routes/home/_l/traces.tsx
@@ -1,0 +1,299 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
+
+import type { ForgeTestTraceType } from "@ethui/types/traces";
+import { TraceView } from "#/components/TraceViewer";
+import { type TreeNode, convertToTreeData } from "#/lib/convertForgeTestTrace";
+
+import { Button } from "@ethui/ui/components/shadcn/button";
+import { open } from "@tauri-apps/plugin-dialog";
+import { readTextFile } from "@tauri-apps/plugin-fs";
+import { Interface } from "ethers";
+import { useInvoke } from "#/hooks/useInvoke";
+import { useContextStore } from "#/lib/contextStore";
+import {
+  parseConstructorData,
+  parseFunctionData,
+  parseLog,
+  splitConstructorFromArguments,
+} from "#/lib/dataParser";
+import { useAbiStore } from "#/store/useAbiStore";
+
+export const Route = createFileRoute("/home/_l/traces")({
+  beforeLoad: () => ({ breadcrumb: "Traces" }),
+  component: TraceViewer,
+});
+
+type ForgeAbi = {
+  path: string;
+  project: string;
+  solidity_file: string;
+  name: string;
+  code: string;
+  abi: any;
+  method_identifiers: Record<string, string>;
+};
+
+type ABICollection = {
+  interface: Interface;
+  contractBytecode: string;
+  methodIdentifiers: Record<string, string>;
+};
+
+function parseAbis(forgeAbis: ForgeAbi[]) {
+  const abiCollection: Record<string, ABICollection> = {};
+  const selectors: Record<string, string[]> = {};
+  const signatures: Record<string, string[]> = {};
+  const selectorsMap: Record<string, string> = {};
+
+  if (forgeAbis) {
+    for (const forgeAbi of forgeAbis) {
+      const methodIdentifiers = forgeAbi.method_identifiers;
+      const name = forgeAbi.name;
+
+      abiCollection[name] = {
+        interface: new Interface(forgeAbi.abi),
+        contractBytecode: forgeAbi.code,
+        methodIdentifiers,
+      };
+
+      for (const [signature, selector] of Object.entries(methodIdentifiers)) {
+        if (!selectors[selector as string]) {
+          selectors[selector as string] = [];
+        }
+        selectors[selector as string].push(name);
+
+        if (!signatures[signature]) {
+          signatures[signature] = [];
+        }
+        signatures[signature].push(name);
+        selectorsMap[selector as string] = signature;
+      }
+    }
+  }
+
+  return { abiCollection, selectors, signatures, selectorsMap };
+}
+
+function TraceViewer() {
+  const [tree, setTree] = useState<TreeNode[] | any>([]);
+  const { abis, selectors, selectorsMap } = useAbiStore();
+  const setAbiData = useAbiStore((state) => state.setAbiData);
+  const { mergeAliasList } = useContextStore();
+
+  const { data: forgeAbis } = useInvoke<ForgeAbi[]>("fetch_forge_abis");
+
+  const handleClick = async () => {
+    const selected = await open({ multiple: false, directory: false });
+
+    if (typeof selected === "string") {
+      const file = await readTextFile(selected);
+      const parsedTrace: ForgeTestTraceType = JSON.parse(file);
+      const computedTree = convertToTreeData(parsedTrace);
+
+      setTree(computedTree);
+
+      if (forgeAbis && forgeAbis?.length > 0) {
+        const parsedAbis = parseAbis(forgeAbis);
+        setAbiData(parsedAbis);
+      }
+    }
+  };
+
+  const addMetadataFieldAsync = useCallback(
+    async (
+      node: TreeNode,
+      rootNode: TreeNode,
+    ): Promise<Record<string, string>> => {
+      const aliasSetInstance: Record<string, string> = {};
+      if (node.metadata) {
+        if (node.metadata.nodeType === "eventNode") {
+          const address = node.metadata.contractAddress;
+          const abiName = rootNode.metadata.newContractsCreated[address];
+          const abiObj = abis[abiName];
+          if (abiObj) {
+            node.metadata.details = parseLog(
+              abiObj.interface,
+              node.metadata.logInfo,
+            );
+          }
+        }
+
+        if (node.metadata.nodeType === "traceNode") {
+          const address = node.metadata.traceInfo.trace.address;
+          // match address to new contract
+          if (
+            node.metadata.traceInfo?.trace.kind === "CREATE" ||
+            node.metadata.traceInfo?.trace.kind === "CREATE2"
+          ) {
+            for (const abiName in abis) {
+              const abiObj = abis[abiName];
+
+              const split = splitConstructorFromArguments(
+                node.metadata.traceInfo.trace.data,
+              );
+
+              if (abiObj.contractBytecode === split.contractData) {
+                aliasSetInstance[address] = `${abiName}_inst`;
+                rootNode.metadata.newContractsCreated[address] = abiName;
+                node.metadata.details = parseConstructorData(
+                  abiObj.interface,
+                  split.constructorArgs,
+                );
+                node.metadata.details.contractName = abiName;
+              }
+            }
+          }
+
+          if (
+            node.metadata.traceInfo.trace.kind === "CALL" ||
+            node.metadata.traceInfo.trace.kind === "STATICCALL" ||
+            node.metadata.traceInfo.trace.kind === "DELEGATECALL"
+          ) {
+            const signature = node.metadata.traceInfo.trace.data.substring(
+              2,
+              10,
+            );
+            node.metadata.selector = `0x${signature}`;
+
+            // if it's a known contract, directly consult the func sig, otherwise brute force
+            if (rootNode.metadata.newContractsCreated[address]) {
+              const abiName = rootNode.metadata.newContractsCreated[address];
+              const abiObj = abis[abiName];
+              if (abiObj) {
+                // if it has an abi but doesn't have the signature, it may be a proxy. call -> delegate. Search in children
+                for (const fn in abiObj.methodIdentifiers) {
+                  const abiSig = abiObj.methodIdentifiers[fn];
+                  if (abiSig === signature) {
+                    node.metadata.contractName = abiName;
+                    node.metadata.details = parseFunctionData(
+                      abiObj.interface,
+                      `0x${signature}`,
+                      node.metadata.traceInfo.trace.data,
+                      node.metadata.traceInfo.trace.output,
+                      node.metadata.traceInfo.trace.success,
+                    );
+                    break;
+                  }
+                }
+                // If I guessed the contract but it doesn't have the selector, it's probably a proxy.
+                if (!node.metadata.details) {
+                  for (const child of node.children) {
+                    if (!child.metadata.traceInfo) {
+                      continue;
+                    }
+                    const childAbi =
+                      abis[
+                        rootNode.metadata.newContractsCreated[
+                          child.metadata.traceInfo.trace.address
+                        ]
+                      ];
+                    if (childAbi) {
+                      for (const fn in childAbi.methodIdentifiers) {
+                        const abiSig = childAbi.methodIdentifiers[fn];
+                        if (abiSig === signature) {
+                          node.metadata.contractName = abiName;
+                          node.metadata.details = parseFunctionData(
+                            childAbi.interface,
+                            `0x${signature}`,
+                            node.metadata.traceInfo.trace.data,
+                            node.metadata.traceInfo.trace.output,
+                            node.metadata.traceInfo.trace.success,
+                          );
+                          break;
+                        }
+                      }
+                      if (node.metadata.details) {
+                        break;
+                      }
+                    }
+                  }
+                }
+              }
+            } else {
+              if (selectors[signature]) {
+                if (selectors[signature].length === 1) {
+                  rootNode.metadata.newContractsCreated[address] =
+                    selectors[signature][0];
+                  aliasSetInstance[address] = selectors[signature][0];
+                }
+                for (const abiName of selectors[signature]) {
+                  const abiObj = abis[abiName];
+                  const fn = selectorsMap[signature];
+                  const abiSig = abiObj.methodIdentifiers[fn];
+                  if (abiSig === signature) {
+                    node.metadata.contractName = `*${abiName}`;
+                    node.metadata.details = parseFunctionData(
+                      abiObj.interface,
+                      `0x${signature}`,
+                      node.metadata.traceInfo.trace.data,
+                      node.metadata.traceInfo.trace.output,
+                      node.metadata.traceInfo.trace.success,
+                    );
+                    break;
+                  }
+                }
+              } else {
+                console.log("Can't find: ", signature);
+              }
+            }
+          }
+        }
+      } else {
+        node.metadata = {};
+      }
+
+      if (node.children && node.children.length > 0) {
+        for (const child of node.children) {
+          const processedAlias: Record<string, string> =
+            await addMetadataFieldAsync(child, rootNode);
+
+          Object.assign(aliasSetInstance, processedAlias);
+        }
+      }
+
+      return aliasSetInstance;
+    },
+    [abis, selectors, selectorsMap],
+  );
+
+  const processTreeAsync = useCallback(async () => {
+    if (tree?.treeData && abis) {
+      const aliasSetInstance: Record<string, string> = {};
+      const processNodeBatch = async (nodes: TreeNode[]) => {
+        for (const node of nodes) {
+          const processedAlias: Record<string, string> =
+            await addMetadataFieldAsync(node, node);
+          Object.assign(aliasSetInstance, processedAlias);
+        }
+      };
+
+      const queue = [...tree.treeData];
+      const batchSize = 10; // Process nodes in batches
+      while (queue.length > 0) {
+        const batch = queue.splice(0, batchSize);
+        await processNodeBatch(batch);
+      }
+
+      Object.assign(tree.labels, aliasSetInstance);
+      mergeAliasList(aliasSetInstance);
+    }
+  }, [tree, abis, mergeAliasList, addMetadataFieldAsync]);
+
+  useEffect(() => {
+    processTreeAsync();
+  }, [processTreeAsync]);
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        className="fixed right-6 bottom-6 h-fit border p-4"
+        onClick={handleClick}
+      >
+        Load Trace
+      </Button>
+      {tree?.labels && <TraceView nodes={tree.treeData} labels={tree.labels} />}
+    </>
+  );
+}


### PR DESCRIPTION
Why:
* Adds a new tab where we can load a `forge test` trace to be displayed
  in a tree like format. It fetches the local ABIs to help the trace and
  display the appropriate values instead of plain addresses or bytecode

How:
* Adding a new route `/home/_l/traces.tsx` and the components needed to
  render the parsed trace
* Adding `fs` and `dialog` crates from tauri in order to load a file
  from the local filesystem
