### PR TITLE
Set minimum window size

### DIFF
--- a/bin/src/windows/mod.rs
+++ b/bin/src/windows/mod.rs
@@ -24,6 +24,7 @@ pub fn build_window(
     let builder = builder
         .title("")
         .decorations(true)
+        .min_inner_size(500.0, 375.0)
         .title_bar_style(tauri::TitleBarStyle::Overlay);
 
     let window = builder.build().unwrap();


### PR DESCRIPTION
Why:
* Closes #1231

How:
* Setting the minimum inner window size, on MacOS, to be 500x375
