### PR TITLE
Fix removing proxy contract

### DIFF
--- a/.sqlx/query-d252b85cc9a994333c656a26098634fda678998e854e48c50a478105f68b0a5b.json
+++ b/.sqlx/query-d252b85cc9a994333c656a26098634fda678998e854e48c50a478105f68b0a5b.json
@@ -1,10 +1,10 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT proxied_by FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?",
+  "query": "SELECT proxy_for FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?",
   "describe": {
     "columns": [
       {
-        "name": "proxied_by",
+        "name": "proxy_for",
         "ordinal": 0,
         "type_info": "Text"
       }
@@ -16,5 +16,5 @@
       true
     ]
   },
-  "hash": "6b02b2106bd7c3346ffa88c3fd6e73b39bcbf56de5e7900172884d65cb6dd689"
+  "hash": "d252b85cc9a994333c656a26098634fda678998e854e48c50a478105f68b0a5b"
 }

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -93,8 +93,8 @@ pub async fn remove_contract(
 
     db.remove_contract(chain_id, dedup_id, address).await?;
 
-    if let Some(proxy) = has_proxy {
-        Box::pin(remove_contract(chain_id, dedup_id, proxy, db)).await?;
+    if let Some(proxy_for) = has_proxy {
+        Box::pin(remove_contract(chain_id, dedup_id, proxy_for, db)).await?;
     }
 
     ethui_broadcast::ui_notify(UINotify::ContractsUpdated).await;

--- a/crates/db/src/queries/contracts.rs
+++ b/crates/db/src/queries/contracts.rs
@@ -215,7 +215,7 @@ impl DbInner {
         let address = format!("0x{address:x}");
 
         let result = sqlx::query_scalar!(
-            r#"SELECT proxied_by FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?"#,
+            r#"SELECT proxy_for FROM contracts WHERE chain_id = ? AND dedup_id = ? AND address = ?"#,
             chain_id,
             dedup_id,
             address


### PR DESCRIPTION
Why:
* The changes made in #1240 made the removal of a proxy contract from
  the UI break. Previously we were checking if the contract to be
  removed had a proxy and recursing backwards from the implementation

How:
* Updating `get_proxy` to get the `proxy_for` address for a contract
  instead of the `proxied_by` address, so we can recurse from proxy to
  implementation
