### PR TITLE
Update `cc` dependency to fix local Mac build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]


### PR DESCRIPTION
Why:
* There's a new `libusb` release, `1.0.29`. The linker with the previous
  `cc` version was still attempting to search for the previous version
  in the system folders. After tracking the issue back to the `cc` crate
  an update of this package solves the issue

How:
* Running `cargo update cc` to update the `cc` dependency
