### PR TITLE
Add exponencial backoff when checking for new blocks

### DIFF
--- a/crates/sync/anvil/src/tracker.rs
+++ b/crates/sync/anvil/src/tracker.rs
@@ -127,9 +127,10 @@ async fn watch(
                         Ok(b) => {
                             if warned {
                                 tracing::info!("Anvil node is back online at {}", ctx.http_url);
+                                warned = false;
+                                backoff = INITIAL_BACKOFF;
                             }
-                            warned = false;
-                            backoff = INITIAL_BACKOFF;
+
                             break 'wait b;
                         }
                         Err(e) => {

--- a/crates/sync/anvil/src/tracker.rs
+++ b/crates/sync/anvil/src/tracker.rs
@@ -1,12 +1,14 @@
+use std::time::Duration;
+
 use alloy::{
     network::Ethereum,
     providers::{Provider as _, ProviderBuilder, WsConnect, ext::TraceApi as _},
     rpc::types::{Filter, Log, trace::parity::LocalizedTransactionTrace},
 };
 use ethui_abis::IERC20;
-use ethui_types::{prelude::*, DedupChainId, TokenMetadata};
+use ethui_types::{DedupChainId, TokenMetadata, prelude::*};
 use futures::StreamExt as _;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::sleep};
 use tracing::{instrument, trace, warn};
 use url::Url;
 
@@ -95,6 +97,10 @@ async fn watch(
     mut quit_rcv: mpsc::Receiver<()>,
     block_snd: mpsc::UnboundedSender<Msg>,
 ) -> color_eyre::Result<()> {
+    let mut backoff = Duration::from_secs(1);
+    let max_backoff = Duration::from_secs(5);
+    let mut warned = false;
+
     'watcher: loop {
         let from_block = match get_sync_status(&ctx).await {
             None => {
@@ -115,7 +121,26 @@ async fn watch(
             tokio::select! {
                 _ = quit_rcv.recv() => break 'watcher,
                 res = http_provider.get_block_number() => {
-                    if let Ok(b) = res { break 'wait b }
+                    match res {
+                        Ok(b) => {
+                            if warned {
+                                tracing::info!("Anvil node is back online at {}", ctx.http_url);
+                            }
+                            warned = false;
+                            backoff = Duration::from_secs(1);
+                            break 'wait b;
+                        }
+                        Err(e) => {
+                            if !warned {
+                                tracing::warn!("Anvil node not available at {}: {e}", ctx.http_url);
+                                warned = true;
+                            } else {
+                                tracing::debug!("Retrying Anvil connection in {}s...", backoff.as_secs());
+                            }
+                            sleep(backoff).await;
+                            backoff = std::cmp::min(backoff * 2, max_backoff);
+                        }
+                    }
                 }
             };
         };

--- a/crates/sync/anvil/src/tracker.rs
+++ b/crates/sync/anvil/src/tracker.rs
@@ -14,6 +14,9 @@ use url::Url;
 
 use crate::expanders::{expand_logs, expand_traces};
 
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
 #[derive(Debug)]
 pub struct Tracker {
     quit_snd: Option<mpsc::Sender<()>>,
@@ -97,8 +100,8 @@ async fn watch(
     mut quit_rcv: mpsc::Receiver<()>,
     block_snd: mpsc::UnboundedSender<Msg>,
 ) -> color_eyre::Result<()> {
-    let mut backoff = Duration::from_secs(1);
-    let max_backoff = Duration::from_secs(5);
+    let mut backoff = INITIAL_BACKOFF;
+    let max_backoff = MAX_BACKOFF;
     let mut warned = false;
 
     'watcher: loop {

--- a/crates/sync/anvil/src/tracker.rs
+++ b/crates/sync/anvil/src/tracker.rs
@@ -101,7 +101,6 @@ async fn watch(
     block_snd: mpsc::UnboundedSender<Msg>,
 ) -> color_eyre::Result<()> {
     let mut backoff = INITIAL_BACKOFF;
-    let max_backoff = MAX_BACKOFF;
     let mut warned = false;
 
     'watcher: loop {
@@ -130,7 +129,7 @@ async fn watch(
                                 tracing::info!("Anvil node is back online at {}", ctx.http_url);
                             }
                             warned = false;
-                            backoff = Duration::from_secs(1);
+                            backoff = INITIAL_BACKOFF;
                             break 'wait b;
                         }
                         Err(e) => {
@@ -141,7 +140,7 @@ async fn watch(
                                 tracing::debug!("Retrying Anvil connection in {}s...", backoff.as_secs());
                             }
                             sleep(backoff).await;
-                            backoff = std::cmp::min(backoff * 2, max_backoff);
+                            backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
                         }
                     }
                 }


### PR DESCRIPTION
When a anvil provider isn't available , the watcher spams requests until it is started. 

By adding a exponential back-off to the request we can throttle this request when it's not connected while allowing the watcher to keep pooling for a potential anvil. 