### PR TITLE
Fixing address view context menu, and accordion clicks

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -17,7 +17,7 @@
     "@aptabase/tauri": "^0.4.1",
     "@ethui/data": "workspace:*",
     "@ethui/types": "workspace:*",
-    "@ethui/ui": "^0.0.92",
+    "@ethui/ui": "^0.0.97",
     "@fontsource/source-code-pro": "^5.2.5",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.3",

--- a/gui/src/components/AddressView.tsx
+++ b/gui/src/components/AddressView.tsx
@@ -55,7 +55,7 @@ export function AddressView({
     <ClickToCopy text={address}>
       <div
         className={cn(
-          "flex items-center gap-x-1 font-mono",
+          "flex items-center gap-x-1 font-mono hover:bg-accent",
           noTextStyle ? "" : "text-base",
         )}
       >
@@ -72,6 +72,11 @@ export function AddressView({
     </ClickToCopy>
   );
 
+  const clearAlias = () => {
+    invoke("settings_set_alias", { address });
+    refetch();
+  };
+
   if (!contextMenu) return content;
 
   return (
@@ -86,7 +91,7 @@ export function AddressView({
         <ContextMenuItem onClick={() => setAliasFormOpen(true)}>
           Set alias
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => setAliasFormOpen(true)}>
+        <ContextMenuItem onClick={clearAlias}>
           Clear alias
         </ContextMenuItem>
         <ContextMenuItem>

--- a/gui/src/routes/home/_l/transactions.tsx
+++ b/gui/src/routes/home/_l/transactions.tsx
@@ -160,8 +160,8 @@ function Summary({ account, tx }: SummaryProps) {
     <div className="flex items-center gap-x-3">
       <Icon {...{ tx, account }} />
       <BlockNumber number={tx.blockNumber} />
-      <AddressView address={tx.from} /> <span>→</span>
-      {tx.to ? <AddressView address={tx.to} /> : <span>Contract Deploy</span>}
+      <AddressView address={tx.from} contextMenu={false} /> <span>→</span>
+      {tx.to ? <AddressView address={tx.to} contextMenu={false} /> : <span>Contract Deploy</span>}
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/types
       '@ethui/ui':
-        specifier: ^0.0.92
-        version: 0.0.92(@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@19.1.0)))(@tailwindcss/postcss@4.1.11)(@tanstack/react-query@5.83.0(react@19.1.0))(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.59.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)(typescript@5.8.2)(viem@2.31.7(typescript@5.8.2)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.0.97
+        version: 0.0.97(@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@19.1.0)))(@tailwindcss/postcss@4.1.11)(@tanstack/react-query@5.83.0(react@19.1.0))(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.59.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)(typescript@5.8.2)(viem@2.31.7(typescript@5.8.2)(zod@3.25.76))(zod@3.25.76)
       '@fontsource/source-code-pro':
         specifier: ^5.2.5
         version: 5.2.6
@@ -671,6 +671,21 @@ packages:
 
   '@ethui/ui@0.0.92':
     resolution: {integrity: sha512-59ic9DU8dydQ9F3E/ej05Nb8p25jleIHKya61+DXYYVt4dvCUn0jxvhb4yFxBcBF/AUz6d2qAyrj+5O7w//OIQ==}
+    peerDependencies:
+      '@hookform/resolvers': ^5.0.1
+      '@tailwindcss/postcss': 4.1.5
+      '@tanstack/react-query': ^5.81.5
+      '@types/react': ^19
+      '@types/react-dom': ^19
+      react: ^19
+      react-dom: ^19
+      react-hook-form: 7.59.0
+      tailwindcss: ^4.1.5
+      viem: ^2.31
+      zod: ^3.0
+
+  '@ethui/ui@0.0.97':
+    resolution: {integrity: sha512-DzFtvGYRfFBXEi8/jjJILTvkJ9ewIHPkuyowAgSQoF0zrAyhFP90kiwp/a0fl01eFqkBHlAuMFCsUidrOX5Rpg==}
     peerDependencies:
       '@hookform/resolvers': ^5.0.1
       '@tailwindcss/postcss': 4.1.5
@@ -3186,6 +3201,50 @@ snapshots:
       - zod
 
   '@ethui/ui@0.0.92(@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@19.1.0)))(@tailwindcss/postcss@4.1.11)(@tanstack/react-query@5.83.0(react@19.1.0))(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.59.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)(typescript@5.8.2)(viem@2.31.7(typescript@5.8.2)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@ethui/abiparse': 0.0.4(react@19.1.0)(typescript@5.8.2)(zod@3.25.76)
+      '@fontsource/source-code-pro': 5.2.6
+      '@hookform/resolvers': 5.1.1(react-hook-form@7.59.0(react@19.1.0))
+      '@radix-ui/react-accordion': 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collapsible': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-context-menu': 2.2.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dropdown-menu': 2.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-icons': 1.3.2(react@19.1.0)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-scroll-area': 1.2.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-select': 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-switch': 1.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toast': 1.2.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tooltip': 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tailwindcss/postcss': 4.1.11
+      '@tanstack/react-query': 5.83.0(react@19.1.0)
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      cmdk: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      lucide-react: 0.506.0(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-hook-form: 7.59.0(react@19.1.0)
+      tailwind-merge: 3.3.1
+      tailwindcss: 4.1.11
+      tailwindcss-animate: 1.0.7(tailwindcss@4.1.11)
+      viem: 2.31.7(typescript@5.8.2)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@ethui/ui@0.0.97(@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@19.1.0)))(@tailwindcss/postcss@4.1.11)(@tanstack/react-query@5.83.0(react@19.1.0))(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.59.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)(typescript@5.8.2)(viem@2.31.7(typescript@5.8.2)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@ethui/abiparse': 0.0.4(react@19.1.0)(typescript@5.8.2)(zod@3.25.76)
       '@fontsource/source-code-pro': 5.2.6


### PR DESCRIPTION
A couple of fixes for `AddressView`:
- within an accordion header, no longer trigger the context menu, since it would conflict with the accordion's own onClick
- `Clear Alias` option now actually clears instead of opening the modal