### PR TITLE
wallet_revokePermissions endpoint

### DIFF
--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -1,9 +1,9 @@
 use ethui_networks::Networks;
-use ethui_types::{Affinity, DedupChainId, GlobalState, Network, eyre};
+use ethui_types::{eyre, Affinity, DedupChainId, GlobalState, Network};
 
 use crate::{
-    Store,
     permissions::{Permission, PermissionRequest, RequestedPermission},
+    Store,
 };
 
 /// Context for a provider connection
@@ -98,6 +98,19 @@ impl Ctx {
             .collect();
 
         self.permissions.extend(new_permissions);
+
+        ret
+    }
+
+    pub fn revoke_permissions(&mut self, request: PermissionRequest) -> Vec<RequestedPermission> {
+        let ret = request.clone().into_request_permissions_result();
+
+        let new_permissions: Vec<_> = request
+            .into_permissions(self.domain.clone().unwrap())
+            .filter(|p| !self.permissions.contains(p))
+            .collect();
+
+        self.permissions.retain(|p| !new_permissions.contains(p));
 
         ret
     }

--- a/crates/connections/src/ctx.rs
+++ b/crates/connections/src/ctx.rs
@@ -105,12 +105,11 @@ impl Ctx {
     pub fn revoke_permissions(&mut self, request: PermissionRequest) -> Vec<RequestedPermission> {
         let ret = request.clone().into_request_permissions_result();
 
-        let new_permissions: Vec<_> = request
+        let to_revoke: Vec<_> = request
             .into_permissions(self.domain.clone().unwrap())
-            .filter(|p| !self.permissions.contains(p))
             .collect();
 
-        self.permissions.retain(|p| !new_permissions.contains(p));
+        self.permissions.retain(|p| !to_revoke.contains(p));
 
         ret
     }

--- a/crates/connections/src/permissions.rs
+++ b/crates/connections/src/permissions.rs
@@ -1,13 +1,13 @@
 use ethui_types::prelude::*;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Permission {
     pub invoker: String,
     pub parent_capability: String,
     pub caveats: Vec<Caveat>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Caveat {
     pub r#type: String,
     pub value: serde_json::Value,

--- a/crates/proxy-detect/src/lib.rs
+++ b/crates/proxy-detect/src/lib.rs
@@ -75,10 +75,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloy::{primitives::address, providers::ProviderBuilder, transports::http::reqwest::Url};
     use lazy_static::lazy_static;
     use rstest::*;
+
+    use super::*;
 
     lazy_static! {
         static ref MAINNET_RPC: Url = Url::parse(
@@ -100,7 +101,7 @@ mod tests {
     #[case::eip897(address!("0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B"), ProxyType::Comptroller(address!("0xbafe01ff935c7305907c33bf824352ee5979b526")))]
     #[tokio::test]
     async fn mainnet(#[case] proxy: Address, #[case] impl_: ProxyType) {
-        let provider = ProviderBuilder::new().on_http(MAINNET_RPC.clone());
+        let provider = ProviderBuilder::new().connect_http(MAINNET_RPC.clone());
 
         let result = detect_proxy(proxy, &provider).await.unwrap();
 
@@ -112,7 +113,7 @@ mod tests {
     #[case::dai(address!("0x6B175474E89094C44Da98b954EedeAC495271d0F"))]
     #[tokio::test]
     async fn not_proxy(#[case] proxy: Address) {
-        let provider = ProviderBuilder::new().on_http(MAINNET_RPC.clone());
+        let provider = ProviderBuilder::new().connect_http(MAINNET_RPC.clone());
 
         let result = detect_proxy(proxy, &provider).await.unwrap();
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -112,6 +112,7 @@ impl Handler {
         self_handler!("eth_signTypedData", Self::eth_sign_typed_data_v4);
         self_handler!("eth_signTypedData_v4", Self::eth_sign_typed_data_v4);
         self_handler!("wallet_requestPermissions", Self::request_permissions);
+        self_handler!("wallet_revokePermissions", Self::revoke_permissions);
         self_handler!("wallet_getPermissions", Self::get_permissions);
         self_handler!("wallet_addEthereumChain", Self::add_chain);
         self_handler!("wallet_updateEthereumChain", Self::update_chain);
@@ -176,6 +177,17 @@ impl Handler {
     ) -> jsonrpc_core::Result<serde_json::Value> {
         let request = params.parse::<PermissionRequest>().unwrap();
         let ret = ctx.request_permissions(request);
+
+        Ok(json!(ret))
+    }
+
+    #[tracing::instrument(skip(params))]
+    async fn revoke_permissions(
+        params: Params,
+        mut ctx: Ctx,
+    ) -> jsonrpc_core::Result<serde_json::Value> {
+        let request = params.parse::<PermissionRequest>().unwrap();
+        let ret = ctx.revoke_permissions(request);
 
         Ok(json!(ret))
     }


### PR DESCRIPTION
while we don't really use these permissions at the moment, this will silence an error on clients whenever the wallet is disconnected