### PR TITLE
Add Route guard

### DIFF
--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -138,14 +138,14 @@ function CustomSidebarMenuItem({
 
   return (
     <SidebarMenuItem key={title}>
-      <SidebarMenuButton asChild>
-        <Link
-          to={url}
-          className={cn(
-            url === location.pathname &&
-              "bg-primary text-accent hover:bg-primary hover:text-accent",
-          )}
-        >
+      <SidebarMenuButton
+        asChild
+        className={cn(
+          url === location.pathname &&
+            "bg-primary text-accent hover:bg-primary hover:text-accent",
+        )}
+      >
+        <Link to={url}>
           {icon}
           {title}
         </Link>
@@ -182,16 +182,14 @@ function CollapsibleMenuSection({
           <SidebarMenuSub>
             {items.map((item) => (
               <SidebarMenuItem key={item.title}>
-                <SidebarMenuButton asChild>
-                  <Link
-                    to={item.url}
-                    className={cn(
-                      item.url === location.pathname &&
-                        "bg-primary text-accent hover:bg-primary hover:text-accent",
-                    )}
-                  >
-                    {item.title}
-                  </Link>
+                <SidebarMenuButton
+                  asChild
+                  className={cn(
+                    item.url === location.pathname &&
+                      "bg-primary text-accent hover:bg-primary hover:text-accent",
+                  )}
+                >
+                  <Link to={item.url}>{item.title}</Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))}

--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -86,13 +86,11 @@ export function AppSidebar() {
               {items.map((item) => (
                 <CustomSidebarMenuItem key={item.title} {...item} />
               ))}
-              {isAnvilNetwork && (
-                <CollapsibleMenuSection
-                  icon={<Globe />}
-                  title="Explorer"
-                  items={explorerItems}
-                />
-              )}
+              <CollapsibleMenuSection
+                icon={<Globe />}
+                title="Explorer"
+                items={getExplorerItems(isAnvilNetwork)}
+              />
               <CollapsibleMenuSection
                 icon={<Cog />}
                 title="Settings"
@@ -203,7 +201,11 @@ function CollapsibleMenuSection({
     </Collapsible>
   );
 }
-
+function getExplorerItems(isAnvilNetwork: boolean) {
+  return isAnvilNetwork
+    ? explorerItems
+    : explorerItems.filter((item) => item.title !== "Addresses");
+}
 // Menu items.
 const items = [
   {

--- a/gui/src/components/AppSidebar.tsx
+++ b/gui/src/components/AppSidebar.tsx
@@ -199,6 +199,7 @@ function CollapsibleMenuSection({
     </Collapsible>
   );
 }
+
 function getExplorerItems(isAnvilNetwork: boolean) {
   return isAnvilNetwork
     ? explorerItems

--- a/gui/src/components/RouteGuard.tsx
+++ b/gui/src/components/RouteGuard.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+interface RouteGuardProps {
+  condition: boolean;
+  fallbackRoute: string;
+  children: React.ReactNode;
+  replace?: boolean;
+  loadingComponent?: React.ComponentType;
+}
+
+export function RouteGuard({
+  condition,
+  fallbackRoute,
+  children,
+  replace = true,
+  loadingComponent: LoadingComponent,
+}: RouteGuardProps) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!condition) {
+      navigate({ to: fallbackRoute, replace });
+    }
+  }, [condition, fallbackRoute, replace, navigate]);
+
+  if (!condition) {
+    return LoadingComponent ? <LoadingComponent /> : null;
+  }
+
+  return <>{children}</>;
+}

--- a/gui/src/components/RouteGuard.tsx
+++ b/gui/src/components/RouteGuard.tsx
@@ -1,31 +1,40 @@
 import { useNavigate } from "@tanstack/react-router";
+import { LoaderCircle } from "lucide-react";
 import { useEffect } from "react";
 
 interface RouteGuardProps {
   condition: boolean;
+  isLoading?: boolean;
   fallbackRoute: string;
   children: React.ReactNode;
   replace?: boolean;
-  loadingComponent?: React.ComponentType;
 }
 
 export function RouteGuard({
   condition,
+  isLoading = false,
   fallbackRoute,
   children,
   replace = true,
-  loadingComponent: LoadingComponent,
 }: RouteGuardProps) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!condition) {
+    if (!isLoading && !condition) {
       navigate({ to: fallbackRoute, replace });
     }
-  }, [condition, fallbackRoute, replace, navigate]);
+  }, [condition, isLoading, fallbackRoute, replace, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center">
+        <LoaderCircle className="animate-spin" />
+      </div>
+    );
+  }
 
   if (!condition) {
-    return LoadingComponent ? <LoadingComponent /> : null;
+    return null;
   }
 
   return <>{children}</>;

--- a/gui/src/routes/dialog/_l/tx-review.$id.tsx
+++ b/gui/src/routes/dialog/_l/tx-review.$id.tsx
@@ -187,9 +187,9 @@ function Header({ from, to, network }: HeaderProps) {
     <div className=" flex w-full items-stretch justify-between self-center">
       <h1 className="font-xl">
         <div className="m-2 flex items-center gap-2">
-          <AddressView showLinkExplorer address={from} />
+          <AddressView address={from} />
           <span>→</span>
-          <AddressView showLinkExplorer address={to} />
+          <AddressView address={to} />
         </div>
       </h1>
       <div className="ml-5">
@@ -358,9 +358,9 @@ function Erc20Transfer({ chainId, log }: Erc20TransferProps) {
 
   return (
     <div className=" m-1 flex items-center gap-2">
-      <AddressView showLinkExplorer address={from} />
+      <AddressView address={from} />
       <span>→</span>
-      <AddressView showLinkExplorer address={to} />
+      <AddressView address={to} />
       <IconAddress chainId={chainId} address={log.address} />
       {metadata?.decimals
         ? formatUnits(value, metadata.decimals)

--- a/gui/src/routes/dialog/_l/tx-review.$id.tsx
+++ b/gui/src/routes/dialog/_l/tx-review.$id.tsx
@@ -187,9 +187,9 @@ function Header({ from, to, network }: HeaderProps) {
     <div className=" flex w-full items-stretch justify-between self-center">
       <h1 className="font-xl">
         <div className="m-2 flex items-center gap-2">
-          <AddressView address={from} />
+          <AddressView showLinkExplorer address={from} />
           <span>→</span>
-          <AddressView address={to} />
+          <AddressView showLinkExplorer address={to} />
         </div>
       </h1>
       <div className="ml-5">
@@ -358,9 +358,9 @@ function Erc20Transfer({ chainId, log }: Erc20TransferProps) {
 
   return (
     <div className=" m-1 flex items-center gap-2">
-      <AddressView address={from} />
+      <AddressView showLinkExplorer address={from} />
       <span>→</span>
-      <AddressView address={to} />
+      <AddressView showLinkExplorer address={to} />
       <IconAddress chainId={chainId} address={log.address} />
       {metadata?.decimals
         ? formatUnits(value, metadata.decimals)

--- a/gui/src/routes/home/_l/explorer/_l/addresses/index.tsx
+++ b/gui/src/routes/home/_l/explorer/_l/addresses/index.tsx
@@ -16,10 +16,14 @@ export const Route = createFileRoute("/home/_l/explorer/_l/addresses/")({
 });
 
 function Addresses() {
-  const { data: isAnvilNetwork = false } = useIsAnvilNetwork();
+  const { data: isAnvilNetwork = false, isLoading } = useIsAnvilNetwork();
 
   return (
-    <RouteGuard condition={isAnvilNetwork} fallbackRoute="/home/account">
+    <RouteGuard
+      condition={isAnvilNetwork}
+      isLoading={isLoading}
+      fallbackRoute="/home/account"
+    >
       <AddressTable />
     </RouteGuard>
   );

--- a/gui/src/routes/home/_l/explorer/_l/addresses/index.tsx
+++ b/gui/src/routes/home/_l/explorer/_l/addresses/index.tsx
@@ -4,8 +4,10 @@ import { createColumnHelper } from "@tanstack/react-table";
 import type { Address } from "viem";
 import { formatEther } from "viem";
 import { AddressView } from "#/components/AddressView";
+import { RouteGuard } from "#/components/RouteGuard";
 import { useAddressBalance } from "#/hooks/useAddressBalance";
 import { useAllAddresses } from "#/hooks/useAllAddresses";
+import { useIsAnvilNetwork } from "#/hooks/useIsAnvilNetwork";
 import { useNetworks } from "#/store/useNetworks";
 
 export const Route = createFileRoute("/home/_l/explorer/_l/addresses/")({
@@ -14,9 +16,13 @@ export const Route = createFileRoute("/home/_l/explorer/_l/addresses/")({
 });
 
 function Addresses() {
-  const { data: addresses = [] } = useAllAddresses();
+  const { data: isAnvilNetwork = false } = useIsAnvilNetwork();
 
-  return <AddressTable addresses={addresses} />;
+  return (
+    <RouteGuard condition={isAnvilNetwork} fallbackRoute="/home/account">
+      <AddressTable />
+    </RouteGuard>
+  );
 }
 
 const columnHelper = createColumnHelper<Address>();
@@ -43,7 +49,9 @@ function BalanceCell({ address }: { address: Address }) {
   return <span className="text-sm">{formatted} ETH</span>;
 }
 
-function AddressTable({ addresses }: { addresses: Address[] }) {
+function AddressTable() {
+  const { data: addresses = [] } = useAllAddresses();
+
   const columns = [
     columnHelper.display({
       id: "address",


### PR DESCRIPTION
This PR adds a route guard to protect certain routes under specific conditions.

Example: If we are on the Anvil network and viewing the `Explorer Addresses` route, switching to another network should not keep us on that page (since it would attempt to load addresses from the not permitted network). Instead, we redirect the user to the `Account` page.